### PR TITLE
ci: disable `next` release and `test` before splitting gems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,8 +97,8 @@ workflows:
   version: 2
   build:
     jobs:
-      - test
-      - test_examples
+      # - test
+      # - test_examples
       - release:
           requires:
             - test
@@ -107,7 +107,7 @@ workflows:
             branches:
               only:
                 - master
-                - develop
+                # - develop
       - github_release:
           requires:
             - release


### PR DESCRIPTION
Given this repo is going to become a monorepo & the directory structure is going to be reworked per this [proposal](https://github.com/dequelabs/html-team-proposals/pull/135/files#diff-5c8c48ed15bd394d11c60d223543e7a7R71), disabling some ci jobs in the interim to avoid unrelated CI failure reports when merged to `develop` branch

Closes issue: NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for accessibility
- [ ] Code is reviewed for security