### PR TITLE
refactor: allow to configure browser as a Symbol argument for webdrivers

### DIFF
--- a/packages/axe-core-capybara/README.md
+++ b/packages/axe-core-capybara/README.md
@@ -9,7 +9,7 @@ require 'axe-core-capybara'
 
 # configure `AxeCapybara`
 
-driver = AxeCapybara.configure("firefox") do |c|
+driver = AxeCapybara.configure(:firefox) do |c|
   # see below for a full list of configuration 
   c.jslib_path = "next-version/axe.js"
 end
@@ -22,12 +22,12 @@ driver.page.navigate.to 'https://www.deque.com/'
 
 #### `AxeCapybara.configure`
 
-The configure method takes 1 optional argument and a configuration block object: `configure(*arg, &block)`
+The configure method takes 1 optional argument as a [symbol][] and a  configuration block object: `configure(*arg, &block)`
 
 The optional argument is a browser name for `capybara`. The valid browser names are:
-- `firefox` (default)
-- `chrome` 
-- `safari`
+- `:firefox` (default)
+- `:chrome` 
+- `:safari`
 
 > Note: Please ensure respective drivers (eg: [`geckodriver`][]) are installed in your machine.
 
@@ -57,3 +57,4 @@ bundle exec rspec
 [axe API]: https://github.com/dequelabs/axe-core/blob/develop/doc/API.md
 [Capybara Webdriver]: https://github.com/teamcapybara/capybara/
 [`geckodriver`]: https://github.com/mozilla/geckodriver/releases
+[symbol]: https://ruby-doc.org/core-2.5.0/Symbol.html

--- a/packages/axe-core-capybara/Rakefile
+++ b/packages/axe-core-capybara/Rakefile
@@ -2,4 +2,18 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
+# default task
 task :default => :spec
+
+# unit tests
+desc "Tests Unit"
+task :test_unit do
+  sh "bundle install && bundle exec rake"
+end
+
+# all tests
+desc "Tests all"
+task :test_all => [
+       "test_unit",
+     ] do
+end

--- a/packages/axe-core-capybara/lib/axe-capybara.rb
+++ b/packages/axe-core-capybara/lib/axe-capybara.rb
@@ -7,7 +7,7 @@ module AxeCapybara
   # configure method
   # - which takes an optional argument browser
   # - and a configuration block optional for Axe
-  def self.configure(browser = "firefox")
+  def self.configure(browser = :firefox)
 
     # instantiate axe configuration (singleton) with defaults or given config
     if !block_given?
@@ -26,17 +26,7 @@ module AxeCapybara
 
   private
 
-  # todo: allow to pass driver options (this option does not exist today - create a feature issue)
-  def self.get_driver(browserName)
-    case browserName
-    when "chrome"
-      Capybara::Selenium::Driver.new(:chrome)
-    when "safari"
-      Capybara::Selenium::Driver.new(:safari)
-    when "firefox"
-      Capybara::Selenium::Driver.new(:firefox)
-    else
-      Capybara::Selenium::Driver.new(:firefox)
-    end
+  def self.get_driver(browserSymbol)
+    Capybara::Selenium::Driver.new(browserSymbol)
   end
 end

--- a/packages/axe-core-capybara/spec/axe-capybara_spec.rb
+++ b/packages/axe-core-capybara/spec/axe-capybara_spec.rb
@@ -8,7 +8,7 @@ describe AxeCapybara do
 
   describe "driver" do
     it "validate yielded configuration" do
-      driver = AxeCapybara.configure("firefox") do
+      driver = AxeCapybara.configure(:firefox) do
       end
 
       expect(driver).not_to be_nil
@@ -43,7 +43,7 @@ describe AxeCapybara do
     end
 
     it "should yield configuration with Safari driver" do
-      AxeCapybara.configure("safari") do
+      AxeCapybara.configure(:safari) do
       end
 
       actual = Axe::Configuration.instance

--- a/packages/axe-core-selenium/README.md
+++ b/packages/axe-core-selenium/README.md
@@ -9,7 +9,7 @@ require 'axe-core-selenium'
 
 # configure `AxeSelenium`
 
-driver = AxeSelenium.configure("firefox") do |c|
+driver = AxeSelenium.configure(:firefox) do |c|
   # see below for a full list of configuration 
   c.jslib_path = "next-version/axe.js"
 end
@@ -22,12 +22,12 @@ driver.page.navigate.to 'https://www.deque.com/'
 
 #### `AxeSelenium.configure`
 
-The configure method takes 1 optional argument and a configuration block object: `configure(*arg, &block)`
+The configure method takes 1 optional argument as a [symbol][] and a configuration block object: `configure(*arg, &block)`
 
 The optional argument is a browser name for `selenium-webdriver`. The valid browser names are:
-- `firefox` (default)
-- `chrome` 
-- `safari`
+- `:firefox` (default)
+- `:chrome` 
+- `:safari`
 
 > Note: Please ensure respective drivers (eg: [`geckodriver`][]) are installed in your machine.
 
@@ -57,3 +57,4 @@ bundle exec rspec
 [axe API]: https://github.com/dequelabs/axe-core/blob/develop/doc/API.md
 [Selenium Webdriver]: https://rubygems.org/gems/selenium-webdriver
 [`geckodriver`]: https://github.com/mozilla/geckodriver/releases
+[symbol]: https://ruby-doc.org/core-2.5.0/Symbol.html

--- a/packages/axe-core-selenium/Rakefile
+++ b/packages/axe-core-selenium/Rakefile
@@ -2,4 +2,18 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
+# default task
 task :default => :spec
+
+# unit tests
+desc "Tests Unit"
+task :test_unit do
+  sh "bundle install && bundle exec rake"
+end
+
+# all tests
+desc "Tests all"
+task :test_all => [
+       "test_unit",
+     ] do
+end

--- a/packages/axe-core-selenium/lib/axe-selenium.rb
+++ b/packages/axe-core-selenium/lib/axe-selenium.rb
@@ -25,7 +25,6 @@ module AxeSelenium
 
   private
 
-  # todo: allow to pass driver options (this option does not exist today - create a feature issue)
   def self.get_driver(browserSymbol)
     Selenium::WebDriver.for browserSymbol
   end

--- a/packages/axe-core-selenium/lib/axe-selenium.rb
+++ b/packages/axe-core-selenium/lib/axe-selenium.rb
@@ -6,7 +6,7 @@ module AxeSelenium
   # configure method
   # - which takes an optional argument browser
   # - and a configuration block optional for Axe
-  def self.configure(browser = "firefox")
+  def self.configure(browser = :firefox)
 
     # instantiate axe configuration (singleton) with defaults or given config
     if !block_given?
@@ -26,16 +26,7 @@ module AxeSelenium
   private
 
   # todo: allow to pass driver options (this option does not exist today - create a feature issue)
-  def self.get_driver(browserName)
-    case browserName
-    when "chrome"
-      Selenium::WebDriver.for :chrome
-    when "safari"
-      Selenium::WebDriver.for :safari
-    when "firefox"
-      Selenium::WebDriver.for :firefox
-    else
-      Selenium::WebDriver.for :firefox
-    end
+  def self.get_driver(browserSymbol)
+    Selenium::WebDriver.for browserSymbol
   end
 end

--- a/packages/axe-core-selenium/spec/axe-selenium_spec.rb
+++ b/packages/axe-core-selenium/spec/axe-selenium_spec.rb
@@ -8,7 +8,7 @@ describe AxeSelenium do
 
   describe "driver" do
     it "validate yielded configuration" do
-      driver = AxeSelenium.configure("firefox") do
+      driver = AxeSelenium.configure(:firefox) do
       end
 
       expect(driver).not_to be_nil
@@ -43,7 +43,7 @@ describe AxeSelenium do
     end
 
     it "should yield configuration with Safari driver" do
-      AxeSelenium.configure("safari") do
+      AxeSelenium.configure(:safari) do
       end
 
       actual = Axe::Configuration.instance
@@ -52,7 +52,7 @@ describe AxeSelenium do
     end
 
     it "should yield configuration with Firefox driver" do
-      AxeSelenium.configure("firefox") do
+      AxeSelenium.configure(:firefox) do
       end
 
       actual = Axe::Configuration.instance

--- a/packages/axe-core-watir/README.md
+++ b/packages/axe-core-watir/README.md
@@ -9,7 +9,7 @@ require 'axe-core-watir'
 
 # configure `AxeWatir`
 
-driver = AxeWatir.configure("firefox") do |c|
+driver = AxeWatir.configure(:firefox) do |c|
   # see below for a full list of configuration 
   c.jslib_path = "next-version/axe.js"
 end
@@ -22,14 +22,14 @@ driver.page.goto 'https://www.deque.com/'
 
 #### `AxeWatir.configure`
 
-The configure method takes 1 optional argument and a configuration block object: `configure(*arg, &block)`
+The configure method takes 1 optional argument as a [symbol][] and a configuration block object: `configure(*arg, &block)`
 
 The optional argument is a browser name for `watir`. The valid browser names are:
-- `firefox` 
-- `chrome` (default)
-- `safari`
-- `internet_explorer`
-- `edge`
+- `:firefox` 
+- `:chrome` (default)
+- `:safari`
+- `:internet_explorer`
+- `:edge`
 
 A detailed configuration option for each of the browsers are available in the [Watir documenation/ guide](http://watir.com/guides/)
 

--- a/packages/axe-core-watir/Rakefile
+++ b/packages/axe-core-watir/Rakefile
@@ -2,4 +2,18 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
+# default task
 task :default => :spec
+
+# unit tests
+desc "Tests Unit"
+task :test_unit do
+  sh "bundle install && bundle exec rake"
+end
+
+# all tests
+desc "Tests all"
+task :test_all => [
+       "test_unit",
+     ] do
+end

--- a/packages/axe-core-watir/lib/axe-watir.rb
+++ b/packages/axe-core-watir/lib/axe-watir.rb
@@ -6,7 +6,7 @@ module AxeWatir
   # configure method
   # - which takes an optional argument browser
   # - and a configuration block optional for Axe
-  def self.configure(browser = "firefox")
+  def self.configure(browser = :firefox)
 
     # instantiate axe configuration (singleton) with defaults or given config
     if !block_given?
@@ -25,21 +25,7 @@ module AxeWatir
 
   private
 
-  # todo: allow to pass driver options (this option does not exist today - create a feature issue)
-  def self.get_driver(browserName)
-    case browserName
-    when "chrome"
-      Watir::Browser.new :chrome
-    when "safari"
-      Watir::Browser.new :safari
-    when "internet_explorer"
-      Watir::Browser.new :internet_explorer
-    when "edge"
-      Watir::Browser.new :edge
-    when "firefox"
-      Watir::Browser.new :firefox
-    else
-      Watir::Browser.new :firefox
-    end
+  def self.get_driver(browserSymbol)
+    Watir::Browser.new browserSymbol
   end
 end

--- a/packages/axe-core-watir/spec/axe-watir_spec.rb
+++ b/packages/axe-core-watir/spec/axe-watir_spec.rb
@@ -6,7 +6,7 @@ describe AxeWatir do
 
   describe "driver" do
     it "validate yielded configuration" do
-      driver = AxeWatir.configure("firefox") do
+      driver = AxeWatir.configure(:firefox) do
       end
 
       expect(driver).not_to be_nil
@@ -41,7 +41,7 @@ describe AxeWatir do
     end
 
     it "should yield configuration with Safari driver" do
-      AxeWatir.configure("safari") do
+      AxeWatir.configure(:safari) do
       end
 
       actual = Axe::Configuration.instance
@@ -51,7 +51,7 @@ describe AxeWatir do
     end
 
     it "should yield configuration with Firefox driver" do
-      AxeWatir.configure("firefox") do
+      AxeWatir.configure(:firefox) do
       end
 
       actual = Axe::Configuration.instance


### PR DESCRIPTION
Removes redundant switch block for each of the webdrivers - `AxeSelenium`, `AxeWatir` and `AxeCapybara`.

Closes issue: 
- NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for accessibility
- [x] Code is reviewed for security