### PR TITLE
chore: add `dependabot` config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,6 +1,16 @@
 version: 1
 update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "weekly"
+    default_labels:
+      - "axe_api_deps_bot"
   - package_manager: "ruby:bundler"
+    directory: "/packages/axe-core-api"
+    update_schedule: "weekly"
+    default_labels:
+      - "axe_api_deps_bot"
+  - package_manager: "javascript"
     directory: "/packages/axe-core-api"
     update_schedule: "weekly"
     default_labels:

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,47 @@
+version: 1
+update_configs:
+  - package_manager: "ruby:bundler"
+    directory: "/packages/axe-core-api"
+    update_schedule: "weekly"
+    default_labels:
+      - "axe_api_deps_bot"
+  - package_manager: "ruby:bundler"
+    directory: "/packages/axe-core-capybara"
+    update_schedule: "weekly"
+    default_labels:
+      - "axe_api_deps_bot"
+  - package_manager: "ruby:bundler"
+    directory: "/packages/axe-core-cucumber"
+    update_schedule: "weekly"
+    default_labels:
+      - "axe_api_deps_bot"
+  - package_manager: "ruby:bundler"
+    directory: "/packages/axe-core-cucumber/e2e/capybara"
+    update_schedule: "weekly"
+    default_labels:
+      - "axe_api_deps_bot"
+  - package_manager: "ruby:bundler"
+    directory: "/packages/axe-core-cucumber/e2e/watir"
+    update_schedule: "weekly"
+    default_labels:
+      - "axe_api_deps_bot"
+  - package_manager: "ruby:bundler"
+    directory: "/packages/axe-core-rspec"
+    update_schedule: "weekly"
+    default_labels:
+      - "axe_api_deps_bot"
+  - package_manager: "ruby:bundler"
+    directory: "/packages/axe-core-rspec/e2e/capybara"
+    update_schedule: "weekly"
+    default_labels:
+      - "axe_api_deps_bot"
+  - package_manager: "ruby:bundler"
+    directory: "/packages/axe-core-selenium"
+    update_schedule: "weekly"
+    default_labels:
+      - "axe_api_deps_bot"
+  - package_manager: "ruby:bundler"
+    directory: "/packages/axe-core-watir"
+    update_schedule: "weekly"
+    default_labels:
+      - "axe_api_deps_bot"


### PR DESCRIPTION
This makes it easier to manage dependabot alerts than their UI.
> The `axe_api_deps_bot` label will help easily filter PR's opened by dependabot.

Closes issue: NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
