### PR TITLE
test: properly scan page in cucumber e2e test

### DIFF
--- a/packages/axe-core-cucumber/e2e/capybara/features/step_definitions/steps.rb
+++ b/packages/axe-core-cucumber/e2e/capybara/features/step_definitions/steps.rb
@@ -2,5 +2,5 @@ Given(/^I am a visitor$/) do
 end
 
 When(/^I visit "(.*?)"$/) do |url|
-  visit url
+  @driver.page.visit url
 end

--- a/packages/axe-core-cucumber/e2e/capybara/features/support/env.rb
+++ b/packages/axe-core-cucumber/e2e/capybara/features/support/env.rb
@@ -5,5 +5,13 @@ require "axe-capybara"
 # definitions available to be used directly in your cucumber features.
 require "axe-cucumber-steps"
 # configure `AxeCapybara`
-@page = AxeCapybara.configure(:firefox) do |c|
+Before do
+  # configure AxeWatir
+  @driver = AxeCapybara.configure(:firefox) do |c|
+  end
+end
+
+# close browser when done
+After do
+  @driver.page.browser.close
 end


### PR DESCRIPTION
So apparently our cucumber capybara tests never worked? What was happening was that a page would open, it would go to "http://abcdcomputech.dequecloud.com/", then it would close and a new page would be opened so that we could run axe on `about:blank`. This makes sure we actually run axe on the page we navigate to.

Closes issue: https://github.com/dequelabs/axe-core-gems/issues/183

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
