### PR TITLE
fix: correctly run on iframes

### DIFF
--- a/packages/axe-core-api/lib/axe/configuration.rb
+++ b/packages/axe-core-api/lib/axe/configuration.rb
@@ -26,7 +26,7 @@ module Axe
     # init
     def initialize
       @page = :page
-      @skip_iframes = :skip_iframes
+      @skip_iframes = nil
       @jslib_path = get_root + "/node_modules/axe-core/axe.min.js"
     end
 

--- a/packages/axe-core-api/lib/axe/core.rb
+++ b/packages/axe-core-api/lib/axe/core.rb
@@ -31,6 +31,7 @@ module Axe
     end
 
     def wrap_driver(driver)
+      driver = driver.driver if driver.respond_to? :driver
       ::WebDriverScriptAdapter::QuerySelectorAdapter.wrap(
         ::WebDriverScriptAdapter::FrameAdapter.wrap(
           ::WebDriverScriptAdapter::ExecuteAsyncScriptAdapter.wrap(


### PR DESCRIPTION
semi-breaking change: Runs in iframes by defalut.

Before, `skip_iframes` had been set to true by default.

Closes issue: https://github.com/dequelabs/axe-core-gems/issues/164

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**

- [ ] Follows the commit message policy, appropriate for next version
- [ ] Code is reviewed for security
