### PR TITLE
chore: add `call_verbatim` method

### DIFF
--- a/packages/axe-core-api/lib/axe/core.rb
+++ b/packages/axe-core-api/lib/axe/core.rb
@@ -21,6 +21,10 @@ module Axe
       end
     end
 
+    def call_verbatim(callable)
+      callable.call @page
+    end
+
     private
 
     def load_axe_core(source)

--- a/packages/axe-core-api/spec/axe/core_spec.rb
+++ b/packages/axe-core-api/spec/axe/core_spec.rb
@@ -35,5 +35,15 @@ module Axe
         expect(run).to have_received(:call).with(page)
       end
     end
+
+    describe "call_verbatim" do
+      let(:run) { spy("run") }
+
+      it "should invoke the callable in the page" do
+        core.call_verbatim(run)
+
+        expect(run).to have_received(:call).with(page)
+      end
+    end
   end
 end


### PR DESCRIPTION
This is needed to support 4.3.x in devtools
