### PR TITLE
fix: make webdriver frameworks to development dependencies

### DIFF
--- a/packages/axe-core-api/axe-core-api.gemspec
+++ b/packages/axe-core-api/axe-core-api.gemspec
@@ -24,13 +24,13 @@ Gem::Specification.new do |spec|
   ]
 
   spec.add_dependency "dumb_delegator"
-  spec.add_dependency "capybara"
-  spec.add_dependency "selenium-webdriver"
-  spec.add_dependency "watir"
   spec.add_dependency "virtus"
 
   spec.add_development_dependency "bundler", "~> 2.1"
+  spec.add_development_dependency "capybara"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-its"
+  spec.add_development_dependency "selenium-webdriver"
+  spec.add_development_dependency "watir"
 end


### PR DESCRIPTION
The option of which webdriver framework to import/use should not be explicitly made in the core API gem. 

To use this gem one would need to include one or more of the webdriver gems, as such this change is a breaking change. But the decision as to which to import really should come down to the user.

When the `axe-core-api` gem was first created (#113) the various webdrivers were included as development dependencies, however it looks like this was changed in #134 by @jeeyyy. I think it would be important to understand why that change was made so this doesn't introduce any regressions. I couldn't see any explanation in #134 that would suggest why.

Closes issue: #176
