### PR TITLE
fix: make webdriver frameworks to development dependencies

### DIFF
--- a/packages/axe-core-api/axe-core-api.gemspec
+++ b/packages/axe-core-api/axe-core-api.gemspec
@@ -24,13 +24,13 @@ Gem::Specification.new do |spec|
   ]
 
   spec.add_dependency "dumb_delegator"
-  spec.add_dependency "capybara"
-  spec.add_dependency "selenium-webdriver"
-  spec.add_dependency "watir"
   spec.add_dependency "virtus"
 
   spec.add_development_dependency "bundler", "~> 2.1"
+  spec.add_development_dependency "capybara"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-its"
+  spec.add_development_dependency "selenium-webdriver"
+  spec.add_development_dependency "watir"
 end


### PR DESCRIPTION
cherry-picking commits from https://github.com/dequelabs/axe-core-gems/pull/203 to get CircleCI to run properly 