### PR TITLE
fix: Allow `none` values for ValueObject, since can be set by CheckedNode result type

### DIFF
--- a/packages/axe-core-api/lib/axe/api/value_object.rb
+++ b/packages/axe-core-api/lib/axe/api/value_object.rb
@@ -3,7 +3,7 @@ require 'virtus'
 module Axe
   module API
     class ValueObject
-      include ::Virtus.value_object mass_assignment: false, nullify_blank: true
+      include ::Virtus.value_object mass_assignment: false, nullify_blank: false
     end
   end
 end


### PR DESCRIPTION
I was trying to setup Axe in my Minitest test suite (following the general idea presented [here](170)), and I hit an error that took me a while to track down. I was using this as my helper method:
```ruby
def assert_accessible(page)
  matcher = Axe::Matchers::BeAxeClean.new

  assert(matcher.matches?(page), matcher.failure_message)
end
```

and in my `assert` call I kept getting this error:
```
NoMethodError: undefined method `reject' for nil:NilClass
```

After digging into the backtrace and your source code, I found that the source of the problem was building up the `failure_message` for the audit results:

https://github.com/dequelabs/axe-core-gems/blob/5a82425b2bbf494e191f8d0ab17537e8e58a832d/packages/axe-core-api/lib/axe/api/results.rb#L44

In my case, I was hitting a problem when inspecting the `CheckedNode` results:

https://github.com/dequelabs/axe-core-gems/blob/5a82425b2bbf494e191f8d0ab17537e8e58a832d/packages/axe-core-api/lib/axe/api/results/checked_node.rb#L22

Specifically, `none` at this point was `nil`. 

I saw at the top of the file that you were using Virtus to declare that this value should be an Array, and thus should default to being an empty array and not `nil`. In experimenting, I found that it was becoming `nil` because of the `nullify_blank` option being used in the `ValueObject` setup:

https://github.com/dequelabs/axe-core-gems/blob/5a82425b2bbf494e191f8d0ab17537e8e58a832d/packages/axe-core-api/lib/axe/api/value_object.rb#L6

When I manually switched this to false, my tests started working as expected.

I am not opening a PR immediately, however, because I'm not sure why this option was added in the first place and whether changing it might break something else. So I thought I would inquire first.


Closes issue: #[196](https://github.com/dequelabs/axe-core-gems/issues/196)
