### PR TITLE
chore: Allow `none` values for ValueObject

### DIFF
--- a/packages/axe-core-api/lib/axe/api/value_object.rb
+++ b/packages/axe-core-api/lib/axe/api/value_object.rb
@@ -3,7 +3,7 @@ require 'virtus'
 module Axe
   module API
     class ValueObject
-      include ::Virtus.value_object mass_assignment: false, nullify_blank: true
+      include ::Virtus.value_object mass_assignment: false, nullify_blank: false
     end
   end
 end


### PR DESCRIPTION
Repushed https://github.com/dequelabs/axe-core-gems/pull/228 so that CI can run

