### PR TITLE
fix: work with extremely large results

### DIFF
--- a/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
+++ b/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
@@ -57,7 +57,7 @@ def recursive_compact(thing)
   elsif thing.is_a?(Hash)
     thing.each_with_object({}) do |(k,v), h|
       v = recursive_compact(v)
-      h[k] = v unless [nil, [], {}].include?(v)
+      h[k] = v unless ([nil, [], {}].include?(v) or k == :html)
     end
   else
     thing

--- a/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
+++ b/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
@@ -4,9 +4,9 @@ require "selenium-webdriver"
 require "axe/core"
 require "axe/api/run"
 
-options = Selenium::WebDriver::Chrome::Options.new
+options = Selenium::WebDriver::Firefox::Options.new
 options.add_argument('--headless')
-$driver = Selenium::WebDriver.for :chrome, options: options
+$driver = Selenium::WebDriver.for :firefox, options: options
 $driver.manage.timeouts.implicit_wait = 300
 $driver.manage.timeouts.script_timeout = 300
 

--- a/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
+++ b/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
@@ -271,15 +271,6 @@ describe "axe.finishRun" do
       expect { run_axe }.to raise_error /finishRun failed/
     }
   end
-
-  it "works with large results", :nt => true do
-    $driver.get fixture "/index.html"
-    res = with_js($axe_post_43x + $large_partial_js) { run_axe }
-
-
-    expect(res.results.passes.length).to eq 1
-    expect(res.results.passes[0].id).to eq :'duplicate-id'
-  end
 end
 
 

--- a/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
+++ b/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
@@ -7,8 +7,6 @@ require "axe/api/run"
 options = Selenium::WebDriver::Firefox::Options.new
 options.add_argument('--headless')
 $driver = Selenium::WebDriver.for :firefox, options: options
-$driver.manage.timeouts.implicit_wait = 300
-$driver.manage.timeouts.script_timeout = 300
 
 Run = Axe::API::Run
 
@@ -270,6 +268,15 @@ describe "axe.finishRun" do
     with_js($axe_post_43x + finish_run_throws) {
       expect { run_axe }.to raise_error /finishRun failed/
     }
+  end
+
+  it "works with large results" do
+    $driver.get fixture "/index.html"
+    res = with_js($axe_post_43x + $large_partial_js) { run_axe }
+
+
+    expect(res.results.passes.length).to eq 1
+    expect(res.results.passes[0].id).to eq :'duplicate-id'
   end
 end
 

--- a/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
+++ b/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
@@ -4,9 +4,9 @@ require "selenium-webdriver"
 require "axe/core"
 require "axe/api/run"
 
-options = Selenium::WebDriver::Firefox::Options.new
-options.add_argument('--headless')
-$driver = Selenium::WebDriver.for :firefox, options: options
+options = Selenium::WebDriver::Chrome::Options.new
+# options.add_argument('--headless')
+$driver = Selenium::WebDriver.for :chrome, options: options
 
 Run = Axe::API::Run
 
@@ -270,7 +270,7 @@ describe "axe.finishRun" do
     }
   end
 
-  it "works with large results" do
+  it "works with large results", :nt => true do
     $driver.get fixture "/index.html"
     res = with_js($axe_post_43x + $large_partial_js) { run_axe }
 

--- a/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
+++ b/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
@@ -92,7 +92,7 @@ describe "Crashes" do
 end
 
 describe "frame tests" do
-  it "injects into nested iframes" do
+  it "injects into nested iframes", :fo => true do
     $driver.get fixture "/nested-iframes.html"
     res = run_axe
     expect(res.results.violations).not_to be_empty

--- a/packages/axe-core-api/lib/axe/api/run.rb
+++ b/packages/axe-core-api/lib/axe/api/run.rb
@@ -48,7 +48,7 @@ module Axe
 
           Common::Loader.new(page, lib).load_top_level Axe::Configuration.instance.jslib
           begin
-            axe_finish_run page, partial_results
+            axe_finish_run page
           rescue
             raise StandardError.new "axe.finishRun failed. Please check out https://github.com/dequelabs/axe-core-gems/blob/develop/error-handling.md"
           end
@@ -156,12 +156,12 @@ module Axe
         JS
         page.execute_script_fixed script, chunk
       end
-      def axe_finish_run(page, partial_results)
+      def axe_finish_run(page)
         script = <<-JS
           const partialResults = JSON.parse(window.partialResults || '[]');
           return axe.finishRun(partialResults);
         JS
-        page.execute_script_fixed script, partial_results
+        page.execute_script_fixed script
       end
 
       def axe_shadow_select(page, frame_selector)

--- a/packages/axe-core-api/lib/axe/api/run.rb
+++ b/packages/axe-core-api/lib/axe/api/run.rb
@@ -37,7 +37,7 @@ module Axe
         throw partial_results if partial_results.respond_to?("key?") and partial_results.key?("errorMessage")
         results = within_about_blank_context(page) { |page|
           partial_res_str = partial_results.to_json
-          size_limit = 60_000_000
+          size_limit = 20_000_000
           while not partial_res_str.empty? do
             chunk_size = size_limit
             chunk_size = partial_res_str.length if chunk_size > partial_res_str.length

--- a/packages/axe-core-api/lib/axe/api/run.rb
+++ b/packages/axe-core-api/lib/axe/api/run.rb
@@ -36,6 +36,16 @@ module Axe
         partial_results = run_partial_recursive(page, @context, lib, true)
         throw partial_results if partial_results.respond_to?("key?") and partial_results.key?("errorMessage")
         results = within_about_blank_context(page) { |page|
+          partial_res_str = partial_results.to_json
+          size_limit = 15_000_000
+          while not partial_res_str.empty? do
+            chunk_size = size_limit
+            chunk_size = partial_res_str.length if chunk_size > partial_res_str.length
+            chunk = partial_res_str[0..chunk_size-1]
+            partial_res_str = partial_res_str[chunk_size..-1]
+            store_chunk page, chunk
+          end
+
           Common::Loader.new(page, lib).load_top_level Axe::Configuration.instance.jslib
           begin
             axe_finish_run page, partial_results
@@ -138,9 +148,17 @@ module Axe
         return results
       end
 
+      def store_chunk(page, chunk)
+        script = <<-JS
+          const chunk = arguments[0];
+          window.partialResults ??= '';
+          window.partialResults += chunk;
+        JS
+        page.execute_script_fixed script, chunk
+      end
       def axe_finish_run(page, partial_results)
         script = <<-JS
-          const partialResults = arguments[0];
+          const partialResults = JSON.parse(window.partialResults || '[]');
           return axe.finishRun(partialResults);
         JS
         page.execute_script_fixed script, partial_results

--- a/packages/axe-core-api/lib/axe/api/run.rb
+++ b/packages/axe-core-api/lib/axe/api/run.rb
@@ -37,7 +37,7 @@ module Axe
         throw partial_results if partial_results.respond_to?("key?") and partial_results.key?("errorMessage")
         results = within_about_blank_context(page) { |page|
           partial_res_str = partial_results.to_json
-          size_limit = 15_000_000
+          size_limit = 60_000_000
           while not partial_res_str.empty? do
             chunk_size = size_limit
             chunk_size = partial_res_str.length if chunk_size > partial_res_str.length


### PR DESCRIPTION
https://github.com/dequelabs/axe-devtools-npm/issues/1653

Note: 60mil broke webdriver locally. Reduced to 20mil and it works. idk why but I blame ruby