### PR TITLE
chore(release): 4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [4.7.0](https://github.com/dequelabs/axe-core-gems/compare/v4.6.1...v4.7.0) (2023-04-27)
+
+
+### Features
+
+* Update axe-core to v4.7.0 ([#299](https://github.com/dequelabs/axe-core-gems/issues/299)) ([81ca285](https://github.com/dequelabs/axe-core-gems/commit/81ca285e2a8ebda7414b5d0543b732141ea6512d))
+
+
+### Bug Fixes
+
+* **capybara:** open browser based on passed symbol ([#303](https://github.com/dequelabs/axe-core-gems/issues/303)) ([c43ee49](https://github.com/dequelabs/axe-core-gems/commit/c43ee49744133ca22a32dde767d896b376c77b6c))
+* **capybara:** open selected browser ([#305](https://github.com/dequelabs/axe-core-gems/issues/305)) ([311e4da](https://github.com/dequelabs/axe-core-gems/commit/311e4dabfe711c6d2bb0e37e113a86d4c4edcf6a))
+* **capybara:** respect browser choice ([#307](https://github.com/dequelabs/axe-core-gems/issues/307)) ([bb0471d](https://github.com/dequelabs/axe-core-gems/commit/bb0471d6ce31c4accabe03de824053f644e6519a))
+* Update axe-core to v4.6.3 ([#298](https://github.com/dequelabs/axe-core-gems/issues/298)) ([4dbab74](https://github.com/dequelabs/axe-core-gems/commit/4dbab7457b270180c1ae4d5917128dd330aaf0bb))
+* **watir:** spawn firefox windows on windows ([#306](https://github.com/dequelabs/axe-core-gems/issues/306)) ([74de72f](https://github.com/dequelabs/axe-core-gems/commit/74de72f3074559b0d9ab3b3f62e10017010ac20a))
+
 ### [4.6.1](https://github.com/dequelabs/axe-core-gems/compare/v4.6.0...v4.6.1) (2023-04-10)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axe-core-gems",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "license": "MPL-2.0",
   "private": true,
   "repository": {

--- a/packages/axe-core-api/package-lock.json
+++ b/packages/axe-core-api/package-lock.json
@@ -7,13 +7,13 @@
       "name": "axe-core-api",
       "license": "MPL-2.0",
       "dependencies": {
-        "axe-core": "^4.6.3"
+        "axe-core": "^4.7.0"
       }
     },
     "node_modules/axe-core": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.3.tgz",
-      "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.0.tgz",
+      "integrity": "sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==",
       "engines": {
         "node": ">=4"
       }
@@ -21,9 +21,9 @@
   },
   "dependencies": {
     "axe-core": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.3.tgz",
-      "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg=="
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.0.tgz",
+      "integrity": "sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ=="
     }
   }
 }

--- a/packages/axe-core-api/package-lock.json
+++ b/packages/axe-core-api/package-lock.json
@@ -7,13 +7,13 @@
       "name": "axe-core-api",
       "license": "MPL-2.0",
       "dependencies": {
-        "axe-core": "^4.6.0"
+        "axe-core": "^4.6.3"
       }
     },
     "node_modules/axe-core": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.0.tgz",
-      "integrity": "sha512-L3ZNbXPTxMrl0+qTXAzn9FBRvk5XdO56K8CvcCKtlxv44Aw2w2NCclGuvCWxHPw1Riiq3ncP/sxFYj2nUqdoTw==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.3.tgz",
+      "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==",
       "engines": {
         "node": ">=4"
       }
@@ -21,9 +21,9 @@
   },
   "dependencies": {
     "axe-core": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.0.tgz",
-      "integrity": "sha512-L3ZNbXPTxMrl0+qTXAzn9FBRvk5XdO56K8CvcCKtlxv44Aw2w2NCclGuvCWxHPw1Riiq3ncP/sxFYj2nUqdoTw=="
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.3.tgz",
+      "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg=="
     }
   }
 }

--- a/packages/axe-core-api/package.json
+++ b/packages/axe-core-api/package.json
@@ -2,6 +2,6 @@
   "name": "axe-core-api",
   "license": "MPL-2.0",
   "dependencies": {
-    "axe-core": "^4.6.3"
+    "axe-core": "^4.7.0"
   }
 }

--- a/packages/axe-core-api/package.json
+++ b/packages/axe-core-api/package.json
@@ -2,6 +2,6 @@
   "name": "axe-core-api",
   "license": "MPL-2.0",
   "dependencies": {
-    "axe-core": "^4.6.0"
+    "axe-core": "^4.6.3"
   }
 }

--- a/packages/axe-core-capybara/lib/axe-capybara.rb
+++ b/packages/axe-core-capybara/lib/axe-capybara.rb
@@ -25,6 +25,6 @@ module AxeCapybara
   private
 
   def self.get_driver(browserSymbol)
-    Capybara::Selenium::Driver.new(browserSymbol)
+    Capybara::Selenium::Driver.new nil, :browser => browserSymbol
   end
 end

--- a/packages/axe-core-capybara/lib/axe-capybara.rb
+++ b/packages/axe-core-capybara/lib/axe-capybara.rb
@@ -25,6 +25,6 @@ module AxeCapybara
   private
 
   def self.get_driver(browserSymbol)
-    Capybara::Selenium::Driver.new nil, :browser => browserSymbol
+    Capybara::Selenium::Driver.new(nil, browser: browserSymbol)
   end
 end

--- a/packages/axe-core-capybara/lib/axe-capybara.rb
+++ b/packages/axe-core-capybara/lib/axe-capybara.rb
@@ -14,8 +14,7 @@ module AxeCapybara
 
     config = Axe::Configuration.instance
 
-    # provide a capybara webdriver page object
-    config.page = get_driver(browser)
+    config.page = set_driver(browser)
 
     # await and return
     yield config
@@ -24,7 +23,14 @@ module AxeCapybara
 
   private
 
-  def self.get_driver(browserSymbol)
-    Capybara::Selenium::Driver.new(nil, browser: browserSymbol)
+  def self.set_driver(browserSymbol)
+    if browserSymbol == :chrome
+      Capybara.default_driver = :selenium_chrome
+      Capybara.javascript_driver = :selenium_chrome
+    else
+      Capybara.default_driver = :selenium
+      Capybara.javascript_driver = :selenium
+    end
+    Capybara::Selenium::Driver.new(nil, :browser => browserSymbol)
   end
 end

--- a/packages/axe-core-capybara/spec/axe-capybara_spec.rb
+++ b/packages/axe-core-capybara/spec/axe-capybara_spec.rb
@@ -33,6 +33,7 @@ describe AxeCapybara do
       end
       is_chrome = driver.page.execute_script "return !!window.chrome"
       expect(is_chrome).to be true
+      expect(Capybara.default_driver).to be :selenium_chrome
     end
 
     it "defaults to firefox" do
@@ -40,12 +41,14 @@ describe AxeCapybara do
       end
       browser = driver.page.options[:browser]
       expect(browser).to be :firefox
+      expect(Capybara.default_driver).to be :selenium
     end
     it "sets browser correctly" do
       driver = AxeCapybara.configure(:chrome) do
       end
       browser = driver.page.options[:browser]
       expect(browser).to be :chrome
+      expect(Capybara.default_driver).to be :selenium_chrome
     end
 
     it "should yield configuration with specified jslib path" do

--- a/packages/axe-core-capybara/spec/axe-capybara_spec.rb
+++ b/packages/axe-core-capybara/spec/axe-capybara_spec.rb
@@ -27,6 +27,14 @@ describe AxeCapybara do
       }.to yield_with_args(actual)
     end
 
+    # Default is firefox, so we can just check that we can override the default
+    it "sets browser" do
+      driver = AxeCapybara.configure(:chrome) do
+      end
+      is_chrome = driver.page.execute_script "return !!window.chrome"
+      expect(is_chrome).to be true
+    end
+
     it "should yield configuration with specified jslib path" do
       different_axe_path = "different-axe-path/axe.js"
 

--- a/packages/axe-core-capybara/spec/axe-capybara_spec.rb
+++ b/packages/axe-core-capybara/spec/axe-capybara_spec.rb
@@ -35,6 +35,19 @@ describe AxeCapybara do
       expect(is_chrome).to be true
     end
 
+    it "defaults to firefox" do
+      driver = AxeCapybara.configure() do
+      end
+      browser = driver.page.options[:browser]
+      expect(browser).to be :firefox
+    end
+    it "sets browser correctly" do
+      driver = AxeCapybara.configure(:chrome) do
+      end
+      browser = driver.page.options[:browser]
+      expect(browser).to be :chrome
+    end
+
     it "should yield configuration with specified jslib path" do
       different_axe_path = "different-axe-path/axe.js"
 

--- a/packages/axe-core-rspec/e2e/capybara/spec/a11y_spec.rb
+++ b/packages/axe-core-rspec/e2e/capybara/spec/a11y_spec.rb
@@ -2,9 +2,9 @@ require "spec_helper"
 
 # Typical example using standard RSpec dsl
 describe "ABCD CompuTech (RSpec DSL)",
-         :type => :feature, :driver => :selenium do
+         :type => :feature do
   before :each do
-    visit "http://abcdcomputech.dequecloud.com/"
+    page.visit "http://abcdcomputech.dequecloud.com/"
   end
 
   it "is known to be inaccessible, should fail" do

--- a/packages/axe-core-rspec/e2e/capybara/spec/spec_helper.rb
+++ b/packages/axe-core-rspec/e2e/capybara/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require "capybara/rspec"
 require "axe-rspec"
 require "axe-capybara"
 
-@page = AxeCapybara.configure(:firefox) do |c|
+AxeCapybara.configure(:chrome) do |c|
 end
 
 RSpec.configure do |config|

--- a/packages/axe-core-watir/lib/axe-watir.rb
+++ b/packages/axe-core-watir/lib/axe-watir.rb
@@ -24,6 +24,6 @@ module AxeWatir
   private
 
   def self.get_driver(browserSymbol)
-    Watir::Browser.new browserSymbol
+    Watir::Browser.new(browserSymbol)
   end
 end

--- a/version.rb
+++ b/version.rb
@@ -1,5 +1,5 @@
 # this version is used by all the packages
 
 module AxeCoreGems
-  VERSION = "4.6.1"
+  VERSION = "4.7.0"
 end


### PR DESCRIPTION
## [4.7.0](https://github.com/dequelabs/axe-core-gems/compare/v4.6.1...v4.7.0) (2023-04-27)


### Features

* Update axe-core to v4.7.0 ([#299](https://github.com/dequelabs/axe-core-gems/issues/299)) ([81ca285](https://github.com/dequelabs/axe-core-gems/commit/81ca285e2a8ebda7414b5d0543b732141ea6512d))


### Bug Fixes

* **capybara:** open browser based on passed symbol ([#303](https://github.com/dequelabs/axe-core-gems/issues/303)) ([c43ee49](https://github.com/dequelabs/axe-core-gems/commit/c43ee49744133ca22a32dde767d896b376c77b6c))
* **capybara:** open selected browser ([#305](https://github.com/dequelabs/axe-core-gems/issues/305)) ([311e4da](https://github.com/dequelabs/axe-core-gems/commit/311e4dabfe711c6d2bb0e37e113a86d4c4edcf6a))
* **capybara:** respect browser choice ([#307](https://github.com/dequelabs/axe-core-gems/issues/307)) ([bb0471d](https://github.com/dequelabs/axe-core-gems/commit/bb0471d6ce31c4accabe03de824053f644e6519a))
* Update axe-core to v4.6.3 ([#298](https://github.com/dequelabs/axe-core-gems/issues/298)) ([4dbab74](https://github.com/dequelabs/axe-core-gems/commit/4dbab7457b270180c1ae4d5917128dd330aaf0bb))
* **watir:** spawn firefox windows on windows ([#306](https://github.com/dequelabs/axe-core-gems/issues/306)) ([74de72f](https://github.com/dequelabs/axe-core-gems/commit/74de72f3074559b0d9ab3b3f62e10017010ac20a))