### PR TITLE
fix: handle spurious axe.runPartial returning null

### DIFF
--- a/packages/axe-core-api/lib/axe/api/run.rb
+++ b/packages/axe-core-api/lib/axe/api/run.rb
@@ -133,8 +133,11 @@ module Axe
           end
 
           res = axe_run_partial page, context
-          if res.key?("errorMessage")
-            throw res if top_level
+          if res.nil? || res.key?("errorMessage")
+            if top_level
+              throw res unless res.nil?
+              throw "axe.runPartial returned null"
+            end
             return [nil]
           else
             results = [res]

--- a/packages/axe-core-api/spec/axe/api/run_spec.rb
+++ b/packages/axe-core-api/spec/axe/api/run_spec.rb
@@ -86,5 +86,40 @@ module Axe::API
         subject.call(page)
       end
     end
+
+    describe "#run_partial_recursive" do
+      let(:context) { spy("context") }
+      before :each do
+        allow(subject).to receive(:get_frame_context_script).and_return({ "key" => "doesn't matter"})
+        subject.instance_variable_set :@context, context
+      end
+      let(:lib) { "{}" }
+
+      it "should throw errorMessage if top level axe.runPartial errors" do
+        page = spy("page", execute_async_script_fixed: { "errorMessage" => "some error" }) 
+
+        expect {
+          subject.send :run_partial_recursive, page, context, lib, true
+        }.to  raise_error /some error/
+      end
+
+      it "should throw an error if top level axe.runPartial returns null" do
+        page = spy("page", execute_async_script_fixed: nil) 
+        expect {
+          subject.send :run_partial_recursive, page, context, lib, true
+        }.to  raise_error /returned null/
+      end
+
+      it "should return array of nil if not top level and axe.runPartial errors" do
+        page = spy("page", execute_async_script_fixed: nil) 
+        expect(subject.send :run_partial_recursive, page, context, lib, false).to eq [nil]
+      end
+
+      it "should return array of nil if not top level and axe.runPartial returns nil" do
+        page = spy("page", execute_async_script_fixed: { "errorMessage" => "some error" }) 
+        expect(subject.send :run_partial_recursive, page, context, lib, false).to eq [nil]
+      end
+
+    end
   end
 end


### PR DESCRIPTION
Closes issue: https://github.com/dequelabs/axe-core-gems/issues/320

I have not been able to replicate the issue. Nor can I find in our code where we might return `nil`. So I decided to handle it like a frame erroring: We mark the frame with `frame-tested` if its an inner frame and just throw if it is top-level.