### PR TITLE
ci: update `prepare_release.sh` to take optional release level

### DIFF
--- a/.github/scripts/prepare_release.sh
+++ b/.github/scripts/prepare_release.sh
@@ -6,7 +6,15 @@ set -e
 releaseLevel="$1"
 
 oldVersion="$(node -pe 'require("./package.json").version')"
-npx standard-version --release-as "$releaseLevel" --skip.commit=true --skip.tag=true
+
+# If no release level is specified, let commit-and-tag-version handle versioning
+if [ -z "$releaseLevel" ] 
+then
+  npx commit-and-tag-version --skip.commit=true --skip.changelog=true --skip.tag=true
+else
+  npx commit-and-tag-version --release-as "$releaseLevel" --skip.commit=true --skip.changelog=true --skip.tag=true
+fi
+
 newVersion="$(node -pe 'require("./package.json").version')"
 
 sed -i -e "s/  VERSION\\s*=\\s*\"$oldVersion\"/  VERSION = \"$newVersion\"/" version.rb

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "axe-test-fixtures": "github:dequelabs/axe-test-fixtures",
-    "conventional-changelog-cli": "^2.2.2",
-    "standard-version": "^9.5.0"
+    "commit-and-tag-version": "^11.2.4",
+    "conventional-changelog-cli": "^2.2.2"
   }
 }


### PR DESCRIPTION
This PR allows the unnamed argument to be optional, if it's not specified it will default to commit-and-tag-version handling version, otherwise it will release as the specified release level.

<details>
<summary>Without specifying a release level</summary>
<img width="1003" alt="image" src="https://github.com/dequelabs/axe-core-gems/assets/41127686/4a292859-7597-4709-a843-8ece889bf6dd">

</details>


<details>
<summary>With release level</summary>
<img width="989" alt="image" src="https://github.com/dequelabs/axe-core-gems/assets/41127686/9ac818a5-0aa7-4672-9e01-9623dcba3ada">

</details>

Closes: https://github.com/dequelabs/axe-core-gems/issues/337