### PR TITLE
ci: generate changelogs with `commit-and-tag-version`

### DIFF
--- a/.github/scripts/prepare_release.sh
+++ b/.github/scripts/prepare_release.sh
@@ -10,9 +10,9 @@ oldVersion="$(node -pe 'require("./package.json").version')"
 # If no release level is specified, let commit-and-tag-version handle versioning
 if [ -z "$releaseLevel" ] 
 then
-  npx commit-and-tag-version --skip.commit=true --skip.changelog=true --skip.tag=true
+  npx commit-and-tag-version --skip.commit=true --skip.tag=true
 else
-  npx commit-and-tag-version --release-as "$releaseLevel" --skip.commit=true --skip.changelog=true --skip.tag=true
+  npx commit-and-tag-version --release-as "$releaseLevel" --skip.commit=true --skip.tag=true
 fi
 
 newVersion="$(node -pe 'require("./package.json").version')"


### PR DESCRIPTION
The release script is failing due to the new changelogs not being generated

no qa required