### PR TITLE
ci: update sync to master workflow

### DIFF
--- a/.github/workflows/sync-master-develop.yml
+++ b/.github/workflows/sync-master-develop.yml
@@ -1,19 +1,19 @@
 name: Sync master/develop branches
 
 on:
-  pull_request:
-    types: [closed]
-    branches: master
+  push:
+    branches:
+      - master
 
 jobs:
   create_sync_pull_request:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: dequelabs/action-sync-branches@v1
+      - uses: dequelabs/action-sync-branches@v1.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-title: "chore: merge master into develop"
-          pr-reviewers: adnoc,michael-siek,stephenmathieson
+          pr-team-reviewers: axe-api-team
           pr-labels: chore
           pr-template: .github/PULL_REQUEST_TEMPLATE.md


### PR DESCRIPTION
This updates the action to fix the no pr template issue as well as switch to pr team reviewer instead of specific users
no qa required