### PR TITLE
fix: add `Lazy-load Axe::API::Run` to save boot time

### DIFF
--- a/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
+++ b/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
@@ -2,7 +2,7 @@
 require "json" #TODO: REMOVE
 require "selenium-webdriver"
 require "axe/core"
-require "axe/api/run"
+require "axe/api"
 
 options = Selenium::WebDriver::Chrome::Options.new
 # options.add_argument('--headless')

--- a/packages/axe-core-api/lib/axe/api.rb
+++ b/packages/axe-core-api/lib/axe/api.rb
@@ -1,0 +1,5 @@
+module Axe
+  module API
+    autoload :Run, "axe/api/run"
+  end
+end

--- a/packages/axe-core-api/lib/axe/matchers/be_axe_clean.rb
+++ b/packages/axe-core-api/lib/axe/matchers/be_axe_clean.rb
@@ -2,7 +2,7 @@ require "forwardable"
 
 require_relative "../../chain_mail/chainable"
 require_relative "../core"
-require_relative "../api/run"
+require_relative "../api"
 
 module Axe
   module Matchers


### PR DESCRIPTION
Forking cbliard's fork to allow CI to run on this PR.

It saves 95% of load time when doing `require "axe-rspec"`.

The time is actually spent loading the `virtus` library. Deferring the loading of `Axe::API::Run` until needed does in turn defer the loading of `virtus` library.

No QA required.