### PR TITLE
fix: add `Lazy-load Axe::API::Run` to improve boot time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ commands:
     description: Install dependencies and bootstrap packages
     steps:
       - checkout
+      - browser-tools/install-browser-tools
       - node/install:
           node-version: "16.13"
       - run: gem install bundler # setup bundler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
   working_directory: ~/axe-core-gems
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.8
+  browser-tools: circleci/browser-tools@1.4.4
   node: circleci/node@5.0.0
 
 commands:
@@ -17,7 +17,6 @@ commands:
       - browser-tools/install-browser-tools:
           # TODO: remove when chromedriver downloads are fixed
           chrome-version: 116.0.5845.96
-          replace-existing: true
       - node/install:
           node-version: "16.13"
       - run: gem install bundler # setup bundler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ commands:
       - browser-tools/install-browser-tools:
           # TODO: remove when chromedriver downloads are fixed
           chrome-version: 126.0.6478.182
-          replace-existing-chrome: true
       - node/install:
           node-version: "16.13"
       - run: gem install bundler # setup bundler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ commands:
       - browser-tools/install-browser-tools:
           # TODO: remove when chromedriver downloads are fixed
           chrome-version: 126.0.6478.182
+          replace-existing-chrome: true
       - node/install:
           node-version: "16.13"
       - run: gem install bundler # setup bundler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,8 @@ commands:
       - checkout
       - browser-tools/install-browser-tools:
           # TODO: remove when chromedriver downloads are fixed
-          chrome-version: 126.0.6478.182
+          chrome-version: 116.0.5845.96
+          replace-existing: true
       - node/install:
           node-version: "16.13"
       - run: gem install bundler # setup bundler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,7 @@ commands:
     description: Install dependencies and bootstrap packages
     steps:
       - checkout
-      - browser-tools/install-browser-tools:
-          # TODO: remove when chromedriver downloads are fixed
-          chrome-version: 128.0.6601.2
+      - browser-tools/install-browser-tools
       - node/install:
           node-version: "16.13"
       - run: gem install bundler # setup bundler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
   working_directory: ~/axe-core-gems
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.3
+  browser-tools: circleci/browser-tools@1.4.8
   node: circleci/node@5.0.0
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ commands:
       - checkout
       - browser-tools/install-browser-tools:
           # TODO: remove when chromedriver downloads are fixed
-          chrome-version: 126.0.6478.182
+          chrome-version: 128.0.6601.2
       - node/install:
           node-version: "16.13"
       - run: gem install bundler # setup bundler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,9 @@ commands:
     description: Install dependencies and bootstrap packages
     steps:
       - checkout
-      - browser-tools/install-browser-tools
+      - browser-tools/install-browser-tools:
+          # TODO: remove when chromedriver downloads are fixed
+          chrome-version: 116.0.5845.96
       - node/install:
           node-version: "16.13"
       - run: gem install bundler # setup bundler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
   working_directory: ~/axe-core-gems
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.4
+  browser-tools: circleci/browser-tools@1.4.8
   node: circleci/node@5.0.0
 
 commands:
@@ -17,6 +17,7 @@ commands:
       - browser-tools/install-browser-tools:
           # TODO: remove when chromedriver downloads are fixed
           chrome-version: 116.0.5845.96
+          replace-existing-chrome: true
       - node/install:
           node-version: "16.13"
       - run: gem install bundler # setup bundler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ commands:
       - checkout
       - browser-tools/install-browser-tools:
           # TODO: remove when chromedriver downloads are fixed
-          chrome-version: 116.0.5845.96
+          chrome-version: 126.0.6478.182
       - node/install:
           node-version: "16.13"
       - run: gem install bundler # setup bundler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ commands:
       - checkout
       - browser-tools/install-browser-tools:
           # TODO: remove when chromedriver downloads are fixed
-          chrome-version: 116.0.5845.96
+          chrome-version: 126.0.6478.182
           replace-existing-chrome: true
       - node/install:
           node-version: "16.13"

--- a/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
+++ b/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
@@ -5,7 +5,7 @@ require "axe/core"
 require "axe/api"
 
 options = Selenium::WebDriver::Chrome::Options.new
-# options.add_argument('--headless')
+options.add_argument('--headless')
 options.add_argument('--no-sandbox')
 options.add_argument('--disable-dev-shm-usage')
 $driver = Selenium::WebDriver.for :chrome, options: options
@@ -345,7 +345,6 @@ describe "does not throw when given" do
   it "geckodriver" do
     options = Selenium::WebDriver::Firefox::Options.new
     options.add_argument('--headless')
-    options.add_argument('--disable-dev-shm-usage')
     driver = Selenium::WebDriver.for :firefox, options: options
     expect do 
       driver.get fixture "/index.html"

--- a/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
+++ b/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
@@ -5,6 +5,7 @@ require "axe/core"
 require "axe/api"
 
 options = Selenium::WebDriver::Chrome::Options.new
+# options.add_argument('--headless')
 options.add_argument('--no-sandbox')
 options.add_argument('--disable-dev-shm-usage')
 $driver = Selenium::WebDriver.for :chrome, options: options

--- a/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
+++ b/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
@@ -345,6 +345,7 @@ describe "does not throw when given" do
   it "geckodriver" do
     options = Selenium::WebDriver::Firefox::Options.new
     options.add_argument('--headless')
+    options.add_argument('--disable-dev-shm-usage')
     driver = Selenium::WebDriver.for :firefox, options: options
     expect do 
       driver.get fixture "/index.html"

--- a/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
+++ b/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
@@ -5,7 +5,6 @@ require "axe/core"
 require "axe/api"
 
 options = Selenium::WebDriver::Chrome::Options.new
-options.add_argument('--headless')
 options.add_argument('--no-sandbox')
 options.add_argument('--disable-dev-shm-usage')
 $driver = Selenium::WebDriver.for :chrome, options: options

--- a/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
+++ b/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
@@ -5,7 +5,7 @@ require "axe/core"
 require "axe/api"
 
 options = Selenium::WebDriver::Chrome::Options.new
-# options.add_argument('--headless')
+options.add_argument('--headless')
 options.add_argument('--no-sandbox')
 options.add_argument('--disable-dev-shm-usage')
 $driver = Selenium::WebDriver.for :chrome, options: options

--- a/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
+++ b/packages/axe-core-api/e2e/selenium/spec/api_spec.rb
@@ -2,7 +2,7 @@
 require "json" #TODO: REMOVE
 require "selenium-webdriver"
 require "axe/core"
-require "axe/api/run"
+require "axe/api"
 
 options = Selenium::WebDriver::Chrome::Options.new
 # options.add_argument('--headless')

--- a/packages/axe-core-api/lib/axe/api.rb
+++ b/packages/axe-core-api/lib/axe/api.rb
@@ -1,0 +1,5 @@
+module Axe
+  module API
+    autoload :Run, "axe/api/run"
+  end
+end

--- a/packages/axe-core-api/lib/axe/matchers/be_axe_clean.rb
+++ b/packages/axe-core-api/lib/axe/matchers/be_axe_clean.rb
@@ -2,7 +2,7 @@ require "forwardable"
 
 require_relative "../../chain_mail/chainable"
 require_relative "../core"
-require_relative "../api/run"
+require_relative "../api"
 
 module Axe
   module Matchers


### PR DESCRIPTION
It saves 95% of load time when doing `require "axe-rspec"`.

The time is actually spent loading the `virtus` library. Deferring the loading of `Axe::API::Run` until needed does in turn defer the loading of `virtus` library.

No QA required.