### PR TITLE
chore: Install ostruct alongside virtus

### DIFF
--- a/packages/axe-core-api/axe-core-api.gemspec
+++ b/packages/axe-core-api/axe-core-api.gemspec
@@ -24,6 +24,9 @@ Gem::Specification.new do |spec|
   ]
 
   spec.add_dependency "dumb_delegator"
+  # used by virtus; including it to make sure we install the gem and do not
+  # rely on the standard library version, which will be removed in 3.5.0
+  spec.add_dependency "ostruct"
   spec.add_dependency "virtus"
 
   spec.add_development_dependency "bundler", "~> 2.1"

--- a/packages/axe-core-cucumber/axe-core-cucumber.gemspec
+++ b/packages/axe-core-cucumber/axe-core-cucumber.gemspec
@@ -23,6 +23,9 @@ Gem::Specification.new do |spec|
   ]
 
   spec.add_dependency "dumb_delegator"
+  # used by virtus; including it to make sure we install the gem and do not
+  # rely on the standard library version, which will be removed in 3.5.0
+  spec.add_dependency "ostruct"
   spec.add_dependency "virtus"
   # pin to a specific version of axe-core-api
   spec.add_dependency "axe-core-api", AxeCoreGems::VERSION

--- a/packages/axe-core-rspec/axe-core-rspec.gemspec
+++ b/packages/axe-core-rspec/axe-core-rspec.gemspec
@@ -23,6 +23,9 @@ Gem::Specification.new do |spec|
   ]
 
   spec.add_dependency "dumb_delegator"
+  # used by virtus; including it to make sure we install the gem and do not
+  # rely on the standard library version, which will be removed in 3.5.0
+  spec.add_dependency "ostruct"
   spec.add_dependency "virtus"
   # pin to a specific version of axe-core-api
   spec.add_dependency "axe-core-api", AxeCoreGems::VERSION


### PR DESCRIPTION
Closes #402 

Background: ostruct (aka OpenStruct) is part of Ruby's standard library, but it's being pulled out of the standard library and into a gem. For now, both versions are available. If you require the version from the standard library, Ruby 3.3.5 will print a warning urging you to switch over to using the gem version. In Ruby 3.5.0, the standard library version will not exist.

The warning looks like this:

```
/Users/mjacobson/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/virtus-2.0.0/lib/virtus.rb:1: warning: /Users/mjacobson/.rbenv/versions/3.3.5/lib/ruby/3.3.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of virtus-2.0.0 to request adding ostruct into its gemspec.
```

Because axe-core-gems uses virtus, and virtus uses ostruct, users of axe-core-gems will start to see this warning when they upgrade to Ruby 3.3.5.

Ideally, virtus itself would add ostruct to its gemspec, but virtus is discontinued and has not received an update in years and is not likely to receive one again. Given that, I suggest axe-core-gems adds ostruct to its gemspecs, to make sure the gem version is installed and used. That way, no warning will be printed and the gem should be compatible with Ruby 3.5.0.

I tried running `rake build` and thought about committing the changes, but there were more than I expected:

<details>
 <summary>Diff after running `rake build`</summary>

```diff
diff --git a/packages/axe-core-api/Gemfile.lock b/packages/axe-core-api/Gemfile.lock
index c71e6b6..3aa5560 100644
--- a/packages/axe-core-api/Gemfile.lock
+++ b/packages/axe-core-api/Gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: .
   specs:
-    axe-core-api (4.8.0)
+    axe-core-api (4.9.1)
       dumb_delegator
+      ostruct
       virtus

 GEM
@@ -35,8 +36,11 @@ GEM
     language_server-protocol (3.17.0.3)
     matrix (0.4.2)
     mini_mime (1.1.5)
-    nokogiri (1.15.5-arm64-darwin)
+    mini_portile2 (2.8.7)
+    nokogiri (1.15.5)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -100,6 +104,7 @@ GEM

 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23

 DEPENDENCIES
   axe-core-api!
diff --git a/packages/axe-core-capybara/Gemfile.lock b/packages/axe-core-capybara/Gemfile.lock
index 6e71a01..936366c 100644
--- a/packages/axe-core-capybara/Gemfile.lock
+++ b/packages/axe-core-capybara/Gemfile.lock
@@ -1,15 +1,16 @@
 PATH
   remote: ..
   specs:
-    axe-core-api (4.8.0)
+    axe-core-api (4.9.1)
       dumb_delegator
+      ostruct
       virtus

 PATH
   remote: .
   specs:
-    axe-core-capybara (4.8.0)
-      axe-core-api
+    axe-core-capybara (4.9.1)
+      axe-core-api (= 4.9.1)
       dumb_delegator

 GEM
@@ -42,8 +43,11 @@ GEM
     language_server-protocol (3.17.0.3)
     matrix (0.4.2)
     mini_mime (1.1.5)
-    nokogiri (1.15.5-arm64-darwin)
+    mini_portile2 (2.8.7)
+    nokogiri (1.15.5)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -104,6 +108,7 @@ GEM

 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23

 DEPENDENCIES
   axe-core-api!
diff --git a/packages/axe-core-cucumber/Gemfile.lock b/packages/axe-core-cucumber/Gemfile.lock
index 556b6d7..fa7ad04 100644
--- a/packages/axe-core-cucumber/Gemfile.lock
+++ b/packages/axe-core-cucumber/Gemfile.lock
@@ -1,16 +1,18 @@
 PATH
   remote: ..
   specs:
-    axe-core-api (4.8.0)
+    axe-core-api (4.9.1)
       dumb_delegator
+      ostruct
       virtus

 PATH
   remote: .
   specs:
-    axe-core-cucumber (4.8.0)
-      axe-core-api
+    axe-core-cucumber (4.9.1)
+      axe-core-api (= 4.9.1)
       dumb_delegator
+      ostruct
       virtus

 GEM
@@ -58,6 +60,7 @@ GEM
     language_server-protocol (3.17.0.3)
     mini_mime (1.1.5)
     multi_test (1.1.0)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -108,6 +111,7 @@ GEM

 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23

 DEPENDENCIES
   axe-core-api!
diff --git a/packages/axe-core-rspec/Gemfile.lock b/packages/axe-core-rspec/Gemfile.lock
index 596ea3c..8e1a1a6 100644
--- a/packages/axe-core-rspec/Gemfile.lock
+++ b/packages/axe-core-rspec/Gemfile.lock
@@ -1,16 +1,18 @@
 PATH
   remote: ..
   specs:
-    axe-core-api (4.8.0)
+    axe-core-api (4.9.1)
       dumb_delegator
+      ostruct
       virtus

 PATH
   remote: .
   specs:
-    axe-core-rspec (4.8.0)
-      axe-core-api
+    axe-core-rspec (4.9.1)
+      axe-core-api (= 4.9.1)
       dumb_delegator
+      ostruct
       virtus

 GEM
@@ -30,6 +32,7 @@ GEM
     ice_nine (0.11.2)
     json (2.7.0)
     language_server-protocol (3.17.0.3)
+    ostruct (0.6.0)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -78,6 +81,7 @@ GEM

 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23

 DEPENDENCIES
   axe-core-api!
```
</details>

Should I? Happy to push that up, or leave it to y'all when you cut a release.

QA notes: standard regression