### PR TITLE
ci: pin Chrome

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,9 @@ commands:
     description: Install dependencies and bootstrap packages
     steps:
       - checkout
-      - browser-tools/install-browser-tools
+      - browser-tools/install-browser-tools:
+          chrome-version: 126.0.6478.182
+          replace-existing-chrome: true
       - node/install:
           node-version: "16.13"
       - run: gem install bundler # setup bundler


### PR DESCRIPTION
When running CI on [another PR](https://github.com/dequelabs/axe-core-gems/pull/404), Selenium would consistently fail with 
```
Failure/Error: $driver.get fixture "/index.html"
Selenium::WebDriver::Error::InvalidSessionIdError: invalid session id
```

This [appears to be due to resourcing issues for new versions of Chrome](https://stackoverflow.com/questions/56002701/selenium-webdriver-error-invalid-session-id); pinning the Chrome version in CI consistently fixes the issue.

No QA needed.