### PR TITLE
chore: Install ostruct alongside virtus

### DIFF
--- a/packages/axe-core-api/axe-core-api.gemspec
+++ b/packages/axe-core-api/axe-core-api.gemspec
@@ -24,6 +24,9 @@ Gem::Specification.new do |spec|
   ]
 
   spec.add_dependency "dumb_delegator"
+  # used by virtus; including it to make sure we install the gem and do not
+  # rely on the standard library version, which will be removed in 3.5.0
+  spec.add_dependency "ostruct"
   spec.add_dependency "virtus"
 
   spec.add_development_dependency "bundler", "~> 2.1"

--- a/packages/axe-core-cucumber/axe-core-cucumber.gemspec
+++ b/packages/axe-core-cucumber/axe-core-cucumber.gemspec
@@ -23,6 +23,9 @@ Gem::Specification.new do |spec|
   ]
 
   spec.add_dependency "dumb_delegator"
+  # used by virtus; including it to make sure we install the gem and do not
+  # rely on the standard library version, which will be removed in 3.5.0
+  spec.add_dependency "ostruct"
   spec.add_dependency "virtus"
   # pin to a specific version of axe-core-api
   spec.add_dependency "axe-core-api", AxeCoreGems::VERSION

--- a/packages/axe-core-rspec/axe-core-rspec.gemspec
+++ b/packages/axe-core-rspec/axe-core-rspec.gemspec
@@ -23,6 +23,9 @@ Gem::Specification.new do |spec|
   ]
 
   spec.add_dependency "dumb_delegator"
+  # used by virtus; including it to make sure we install the gem and do not
+  # rely on the standard library version, which will be removed in 3.5.0
+  spec.add_dependency "ostruct"
   spec.add_dependency "virtus"
   # pin to a specific version of axe-core-api
   spec.add_dependency "axe-core-api", AxeCoreGems::VERSION


### PR DESCRIPTION
Closes #402 

Background: ostruct (aka OpenStruct) is part of Ruby's standard library, but it's being pulled out of the standard library and into a gem. For now, both versions are available. If you require the version from the standard library, Ruby 3.3.5 will print a warning urging you to switch over to using the gem version. In Ruby 3.5.0, the standard library version will not exist.

The warning looks like this:

```
/Users/mjacobson/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/virtus-2.0.0/lib/virtus.rb:1: warning: /Users/mjacobson/.rbenv/versions/3.3.5/lib/ruby/3.3.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of virtus-2.0.0 to request adding ostruct into its gemspec.
```

Because axe-core-gems uses virtus, and virtus uses ostruct, users of axe-core-gems will start to see this warning when they upgrade to Ruby 3.3.5.

Ideally, virtus itself would add ostruct to its gemspec, but virtus is discontinued and has not received an update in years and is not likely to receive one again. Given that, I suggest axe-core-gems adds ostruct to its gemspecs, to make sure the gem version is installed and used. That way, no warning will be printed and the gem should be compatible with Ruby 3.5.0.

Note: this is a fork of https://github.com/dequelabs/axe-core-gems/pull/403 that allows CI to run.

No QA required.