### PR TITLE
ci: remove `PR_TEMPLATE` from sync workflow

### DIFF
--- a/.github/workflows/sync-master-develop.yml
+++ b/.github/workflows/sync-master-develop.yml
@@ -16,4 +16,3 @@ jobs:
           pr-title: "chore: merge master into develop"
           pr-team-reviewers: axe-api-team
           pr-labels: chore
-          pr-template: .github/PULL_REQUEST_TEMPLATE.md


### PR DESCRIPTION
no qa required