### PR TITLE
fix: allow passing extra options to Selenium::WebDriver

### DIFF
--- a/packages/axe-core-selenium/README.md
+++ b/packages/axe-core-selenium/README.md
@@ -20,7 +20,7 @@ require 'axe-selenium'
 # configure `AxeSelenium`
 
 driver = AxeSelenium.configure(:firefox) do |c|
-  # see below for a full list of configuration 
+  # see below for a full list of configuration
   c.jslib_path = "next-version/axe.js"
 end
 
@@ -28,7 +28,18 @@ end
 driver.page.navigate.to 'https://www.deque.com/'
 ```
 
-### API 
+Custom options can be passed to the underlying driver:
+
+```rb
+require 'axe-selenium'
+
+options = Selenium::WebDriver::Options.firefox
+options.args << '-headless'
+
+driver = AxeSelenium.configure(:firefox, options) {}
+```
+
+### API
 
 #### `AxeSelenium.configure`
 
@@ -36,7 +47,7 @@ The configure method takes 1 optional argument as a [symbol][] and a configurati
 
 The optional argument is a browser name for `selenium-webdriver`. The valid browser names are:
 - `:firefox` (default)
-- `:chrome` 
+- `:chrome`
 - `:safari`
 
 > Note: Please ensure respective drivers (eg: [`geckodriver`][]) are installed in your machine.

--- a/packages/axe-core-selenium/lib/axe-selenium.rb
+++ b/packages/axe-core-selenium/lib/axe-selenium.rb
@@ -4,8 +4,9 @@ require "axe/configuration"
 module AxeSelenium
   # configure method
   # - which takes an optional argument browser
+  # - an optional options (sic) object to configure the underlying driver
   # - and a configuration block optional for Axe
-  def self.configure(browser = :firefox)
+  def self.configure(browser = :firefox, opts = {})
     # instantiate axe configuration (singleton) with defaults or given config
     if !block_given?
       raise Exception.new "Please provide a configure block for AxeSelenium"
@@ -14,7 +15,7 @@ module AxeSelenium
     config = Axe::Configuration.instance
 
     # provide a selenium webdriver page object
-    config.page = get_driver(browser)
+    config.page = get_driver(browser, opts)
 
     # await and return
     yield config
@@ -23,7 +24,7 @@ module AxeSelenium
 
   private
 
-  def self.get_driver(browserSymbol)
-    Selenium::WebDriver.for browserSymbol
+  def self.get_driver(browserSymbol, opts)
+    Selenium::WebDriver.for browserSymbol, options: opts
   end
 end


### PR DESCRIPTION
Some environments like Docker require special options (-headless for example) which is impossible to specify in the current setup. Add an ommitable `opts` parameter for it.