### PR TITLE
ci: install modern versions of chrome and node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,11 +15,9 @@ commands:
     description: Install dependencies and bootstrap packages
     steps:
       - checkout
-      - browser-tools/install-browser-tools:
-          chrome-version: 126.0.6478.182
-          replace-existing-chrome: true
+      - browser-tools/install-browser-tools
       - node/install:
-          node-version: "16.13"
+          node-version: "22"
       - run: gem install bundler # setup bundler
       - run: rake bootstrap # bootstrap packages
 
@@ -87,7 +85,7 @@ jobs:
     steps:
       - checkout
       - node/install:
-          node-version: "16.13"
+          node-version: "22"
       - bootstrap
       - run: bash .circleci/print_license.sh
 


### PR DESCRIPTION
The [build is failing trying to install chrome 126](https://app.circleci.com/pipelines/github/dequelabs/axe-core-gems/839/workflows/7a2c5f9d-709b-42de-83dc-9a803c8671ff/jobs/1834). Unpinning the chrome version so it will install latest. Also updated the node version while I was there.

No QA required