### PR TITLE
fix: remove unneeded `dumb_delegator`, `ostruct`, and `virtus` dependencies

### DIFF
--- a/packages/axe-core-capybara/Gemfile.lock
+++ b/packages/axe-core-capybara/Gemfile.lock
@@ -1,16 +1,16 @@
 PATH
   remote: ..
   specs:
-    axe-core-api (4.8.0)
+    axe-core-api (4.11.1)
       dumb_delegator
+      ostruct
       virtus
 
 PATH
   remote: .
   specs:
-    axe-core-capybara (4.8.0)
-      axe-core-api
-      dumb_delegator
+    axe-core-capybara (4.11.1)
+      axe-core-api (= 4.11.1)
 
 GEM
   remote: https://rubygems.org/
@@ -42,8 +42,13 @@ GEM
     language_server-protocol (3.17.0.3)
     matrix (0.4.2)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.9)
+    nokogiri (1.15.5)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.15.5-arm64-darwin)
       racc (~> 1.4)
+    ostruct (0.6.3)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -104,6 +109,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   axe-core-api!
@@ -117,4 +123,4 @@ DEPENDENCIES
   selenium-webdriver
 
 BUNDLED WITH
-   2.4.10
+   2.6.9

--- a/packages/axe-core-capybara/axe-core-capybara.gemspec
+++ b/packages/axe-core-capybara/axe-core-capybara.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
     README.md
   ]
 
-  spec.add_dependency "dumb_delegator"
   # pin to a specific version of axe-core-api
   spec.add_dependency "axe-core-api", AxeCoreGems::VERSION
 

--- a/packages/axe-core-cucumber/Gemfile.lock
+++ b/packages/axe-core-cucumber/Gemfile.lock
@@ -1,16 +1,17 @@
 PATH
   remote: ..
   specs:
-    axe-core-api (4.8.0)
+    axe-core-api (4.11.1)
       dumb_delegator
+      ostruct
       virtus
 
 PATH
   remote: .
   specs:
-    axe-core-cucumber (4.8.0)
-      axe-core-api
-      dumb_delegator
+    axe-core-cucumber (4.11.1)
+      axe-core-api (= 4.11.1)
+      ostruct
       virtus
 
 GEM
@@ -58,6 +59,7 @@ GEM
     language_server-protocol (3.17.0.3)
     mini_mime (1.1.5)
     multi_test (1.1.0)
+    ostruct (0.6.3)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -108,6 +110,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   axe-core-api!
@@ -120,4 +123,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.4.10
+   2.6.9

--- a/packages/axe-core-cucumber/Gemfile.lock
+++ b/packages/axe-core-cucumber/Gemfile.lock
@@ -11,8 +11,6 @@ PATH
   specs:
     axe-core-cucumber (4.11.1)
       axe-core-api (= 4.11.1)
-      ostruct
-      virtus
 
 GEM
   remote: https://rubygems.org/

--- a/packages/axe-core-cucumber/axe-core-cucumber.gemspec
+++ b/packages/axe-core-cucumber/axe-core-cucumber.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
     README.md
   ]
 
-  spec.add_dependency "dumb_delegator"
   # used by virtus; including it to make sure we install the gem and do not
   # rely on the standard library version, which will be removed in 3.5.0
   spec.add_dependency "ostruct"

--- a/packages/axe-core-cucumber/axe-core-cucumber.gemspec
+++ b/packages/axe-core-cucumber/axe-core-cucumber.gemspec
@@ -22,10 +22,6 @@ Gem::Specification.new do |spec|
     README.md
   ]
 
-  # used by virtus; including it to make sure we install the gem and do not
-  # rely on the standard library version, which will be removed in 3.5.0
-  spec.add_dependency "ostruct"
-  spec.add_dependency "virtus"
   # pin to a specific version of axe-core-api
   spec.add_dependency "axe-core-api", AxeCoreGems::VERSION
 

--- a/packages/axe-core-rspec/Gemfile.lock
+++ b/packages/axe-core-rspec/Gemfile.lock
@@ -1,16 +1,17 @@
 PATH
   remote: ..
   specs:
-    axe-core-api (4.8.0)
+    axe-core-api (4.11.1)
       dumb_delegator
+      ostruct
       virtus
 
 PATH
   remote: .
   specs:
-    axe-core-rspec (4.8.0)
-      axe-core-api
-      dumb_delegator
+    axe-core-rspec (4.11.1)
+      axe-core-api (= 4.11.1)
+      ostruct
       virtus
 
 GEM
@@ -30,6 +31,7 @@ GEM
     ice_nine (0.11.2)
     json (2.7.0)
     language_server-protocol (3.17.0.3)
+    ostruct (0.6.3)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -78,6 +80,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   axe-core-api!
@@ -89,4 +92,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.4.10
+   2.6.9

--- a/packages/axe-core-rspec/Gemfile.lock
+++ b/packages/axe-core-rspec/Gemfile.lock
@@ -11,8 +11,6 @@ PATH
   specs:
     axe-core-rspec (4.11.1)
       axe-core-api (= 4.11.1)
-      ostruct
-      virtus
 
 GEM
   remote: https://rubygems.org/

--- a/packages/axe-core-rspec/axe-core-rspec.gemspec
+++ b/packages/axe-core-rspec/axe-core-rspec.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
     README.md
   ]
 
-  spec.add_dependency "dumb_delegator"
   # used by virtus; including it to make sure we install the gem and do not
   # rely on the standard library version, which will be removed in 3.5.0
   spec.add_dependency "ostruct"

--- a/packages/axe-core-rspec/axe-core-rspec.gemspec
+++ b/packages/axe-core-rspec/axe-core-rspec.gemspec
@@ -22,10 +22,6 @@ Gem::Specification.new do |spec|
     README.md
   ]
 
-  # used by virtus; including it to make sure we install the gem and do not
-  # rely on the standard library version, which will be removed in 3.5.0
-  spec.add_dependency "ostruct"
-  spec.add_dependency "virtus"
   # pin to a specific version of axe-core-api
   spec.add_dependency "axe-core-api", AxeCoreGems::VERSION
 

--- a/packages/axe-core-selenium/axe-core-selenium.gemspec
+++ b/packages/axe-core-selenium/axe-core-selenium.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
     README.md
   ]
 
-  spec.add_dependency "dumb_delegator"
   # pin to a specific version of axe-core-api
   spec.add_dependency "axe-core-api", AxeCoreGems::VERSION
 

--- a/packages/axe-core-watir/axe-core-watir.gemspec
+++ b/packages/axe-core-watir/axe-core-watir.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
     README.md
   ]
 
-  spec.add_dependency "dumb_delegator"
   # pin to a specific version of axe-core-api
   spec.add_dependency "axe-core-api", AxeCoreGems::VERSION
 


### PR DESCRIPTION
I'm like 98% sure these shouldn't be needed outside of `axe-core-api` because the rest of the gems don't use them directly - while these dependencies will still be installed due to the dependency on `axe-core-api`, it makes the dependency tree a little more relaxed when resolving and is more representative of what needs what (especially `virtus` which will one day hopefully be moved off of...)