### PR TITLE
ci: change secret for updating axe-core to use pat

### DIFF
--- a/.github/workflows/update-axe-core.yml
+++ b/.github/workflows/update-axe-core.yml
@@ -17,4 +17,4 @@ jobs:
           node-version: 16
       - uses: dequelabs/axe-api-team-public/.github/actions/create-update-axe-core-pull-request-v1@main
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}


### PR DESCRIPTION
This patch makes the workflow use the PAT stored for the axe-core account. This should have CI kicked off for PRs opened automatically. Where the built-in secret does not as a protection layer against infinite loops by GitHub.

No QA Required