### PR TITLE
feat: add Cuprite (Ferrum/CDP) driver support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,12 +32,17 @@ jobs:
       - run: rake test_unit\[axe-core-selenium\]
       - run: rake test_unit\[axe-core-watir\]
       - run: rake test_unit\[axe-core-capybara\]
+      - run: rake test_unit\[axe-core-cuprite\]
       # unit test - framework integrations
       - run: rake test_unit\[axe-core-cucumber\]
       - run: rake test_unit\[axe-core-rspec\]
       # e2e test - rspec -> capybara
       - run: |
           cd packages/axe-core-rspec && cd e2e/capybara
+          bundle install && bundle exec rspec
+      # e2e test - rspec -> cuprite
+      - run: |
+          cd packages/axe-core-rspec && cd e2e/cuprite
           bundle install && bundle exec rspec
       # e2e test - cucumber -> capybara
       - run: |

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 [![Join our Slack chat](https://img.shields.io/badge/slack-chat-purple.svg?logo=slack)](https://accessibility.deque.com/axe-community)
 
-This repository contains 6 packages/gems, which can be used for automated accessibility testing powered by [axe core][axe-core].
+This repository contains 7 packages/gems, which can be used for automated accessibility testing powered by [axe core][axe-core].
 
 The gems are as below:
 - [`axe-core-api`](./packages/axe-core-api/README.md)
 - [`axe-core-capybara`](./packages/axe-core-capybara/README.md)
+- [`axe-core-cuprite`](./packages/axe-core-cuprite/README.md)
 - [`axe-core-cucumber`](./packages/axe-core-cucumber/README.md)
 - [`axe-core-rspec`](./packages/axe-core-rspec/README.md)
 - [`axe-core-selenium`](./packages/axe-core-selenium/README.md)
@@ -15,7 +16,7 @@ The gems are as below:
 ## Getting Started
 
 Using `axe-core-gems` is a 2 step process.
-- Choosing and configuring a webdriver (Capybara, Watir or Selenium)
+- Choosing and configuring a webdriver (Capybara, Cuprite, Watir or Selenium)
 - Choose a testing framework (RSpec or Cucumber)
 
 Then, add the respective gems to your application:

--- a/packages/axe-core-api/lib/axe/api/run.rb
+++ b/packages/axe-core-api/lib/axe/api/run.rb
@@ -35,6 +35,7 @@ module Axe
         user_page_load = (get_selenium page).manage.timeouts.page_load
         (get_selenium page).manage.timeouts.page_load = 1
         begin
+          page.assert_context_supported!(@context.to_h, Axe::Configuration.instance.skip_iframes) if page.respond_to?(:assert_context_supported!)
           @original_window = window_handle page
           partial_results = run_partial_recursive(page, @context, lib, true)
           throw partial_results if partial_results.respond_to?("key?") and partial_results.key?("errorMessage")
@@ -218,6 +219,8 @@ module Axe
       end
 
       def get_frame_context_script(page)
+        return [] if Axe::Configuration.instance.skip_iframes
+
         script = <<-JS
           const context = arguments[0];
           try {

--- a/packages/axe-core-api/lib/axe/core.rb
+++ b/packages/axe-core-api/lib/axe/core.rb
@@ -1,6 +1,7 @@
 require_relative "../webdriver_script_adapter/execute_async_script_adapter"
 require_relative "../webdriver_script_adapter/frame_adapter"
 require_relative "../webdriver_script_adapter/query_selector_adapter"
+require_relative "../webdriver_script_adapter/cuprite_adapter"
 require_relative "../loader"
 require_relative "./configuration"
 require 'timeout'
@@ -56,7 +57,7 @@ module Axe
 
     def wrap_driver(driver)
       driver = driver.driver if driver.respond_to? :driver
-      ::WebDriverScriptAdapter::QuerySelectorAdapter.wrap(
+      wrapped = ::WebDriverScriptAdapter::QuerySelectorAdapter.wrap(
         ::WebDriverScriptAdapter::FrameAdapter.wrap(
           ::WebDriverScriptAdapter::ExecuteAsyncScriptAdapter.wrap(
             ::WebDriverScriptAdapter::ExecEvalScriptAdapter.wrap(
@@ -65,6 +66,11 @@ module Axe
           )
         )
       )
+      if ::WebDriverScriptAdapter::CupriteAdapter.cuprite_driver?(driver)
+        ::WebDriverScriptAdapter::CupriteAdapter.wrap(wrapped, driver)
+      else
+        wrapped
+      end
     end
   end
 end

--- a/packages/axe-core-api/lib/webdriver_script_adapter/cuprite_adapter.rb
+++ b/packages/axe-core-api/lib/webdriver_script_adapter/cuprite_adapter.rb
@@ -1,0 +1,173 @@
+require "dumb_delegator"
+require_relative "./exec_eval_script_adapter"
+
+module WebDriverScriptAdapter
+  # Presents the Selenium-shaped surface that Axe::API::Run#analyze_post_43x
+  # expects, backed by a Capybara::Cuprite::Driver. This is the object
+  # run.rb's #get_selenium resolves to (via CupriteAdapter#browser).
+  class CupriteBrowserFacade
+    Timeouts = Struct.new(:page_load)
+
+    class Manage
+      def initialize(driver)
+        # Seed page_load from Cuprite's command timeout; value is only ever
+        # read back and restored by run.rb, so a stored attr is sufficient and
+        # avoids perturbing CDP behaviour (about:blank loads instantly).
+        @timeouts = Timeouts.new(driver.respond_to?(:timeout) ? driver.timeout : 1)
+      end
+
+      def timeouts
+        @timeouts
+      end
+    end
+
+    class SwitchTo
+      def initialize(driver)
+        @driver = driver
+      end
+
+      def window(handle)
+        @driver.switch_to_window(handle)
+      end
+
+      def frame(handle)
+        @driver.switch_to_frame(handle)
+      end
+
+      def parent_frame
+        @driver.switch_to_frame(:parent)
+      end
+
+      def default_content
+        @driver.switch_to_frame(:top)
+      end
+    end
+
+    def initialize(driver)
+      @driver = driver
+      @manage = Manage.new(driver)
+      @switch_to = SwitchTo.new(driver)
+    end
+
+    def manage
+      @manage
+    end
+
+    def switch_to
+      @switch_to
+    end
+
+    def get(url)
+      @driver.visit(url)
+    end
+
+    def execute_script(script, *args)
+      @driver.execute_script(script, *args)
+    end
+
+    def window_handle
+      @driver.window_handle
+    end
+    alias current_window_handle window_handle
+
+    def window_handles
+      @driver.window_handles
+    end
+
+    def close
+      @driver.close_window(@driver.window_handle)
+    end
+  end
+
+  # Outermost decorator in the wrap chain for Cuprite drivers. Holds a ref to
+  # the RAW Cuprite driver (not the wrapped chain) so #browser and the *_fixed
+  # methods bypass the Selenium-native assumptions baked into the inner chain.
+  class CupriteAdapter < ::DumbDelegator
+    UNSUPPORTED_IFRAME_MESSAGE = "Cuprite iframe auditing is not supported yet. " \
+      "Set Axe::Configuration#skip_iframes=true to audit only the top-level document, " \
+      "or use a Selenium-backed driver for iframe audits."
+
+    def self.cuprite_driver?(driver)
+      !!(defined?(::Capybara::Cuprite::Driver) && driver.is_a?(::Capybara::Cuprite::Driver))
+    end
+
+    def self.wrap(wrapped, driver)
+      new(wrapped, driver)
+    end
+
+    def initialize(wrapped, driver)
+      super(wrapped)
+      @driver = driver
+    end
+
+    # run.rb#get_selenium drills to `.browser`; hand it the Selenium facade
+    # instead of the raw Capybara::Cuprite::Browser.
+    def browser
+      @facade ||= CupriteBrowserFacade.new(@driver)
+    end
+
+    # Cuprite's execute_script (Ferrum#execute) discards the return value.
+    # Wrap the script body in an async shim so that:
+    #   - `return` statements work inside the original script body.
+    #   - Promise-returning scripts (e.g. axe.finishRun) are awaited via
+    #     Promise.resolve, because Ferrum's evaluate_async uses awaitPromise:true.
+    # The Ferrum template appends its resolve-callback as the last argument,
+    # so we split user args from the callback before re-applying.
+    def execute_script_fixed(script, *args)
+      wrapper = <<~JS
+        var __args = Array.prototype.slice.call(arguments, 0, arguments.length - 1);
+        var __cb  = arguments[arguments.length - 1];
+        try {
+          var __result = (function() { #{script} }).apply(this, __args);
+          Promise.resolve(__result).then(__cb).catch(function(e) {
+            __cb({ errorMessage: e.message });
+          });
+        } catch(e) {
+          __cb({ errorMessage: e.message });
+        }
+      JS
+      result = @driver.evaluate_async_script(wrapper, *args)
+      if result.respond_to?(:key?) && result.key?("errorMessage")
+        raise WebDriverError, result["errorMessage"]
+      end
+
+      result
+    end
+
+    # Use Cuprite's native evaluate_async_script (Ferrum evaluate_async with
+    # awaitPromise: true) so that `cb(promise)` calls — the pattern axe's
+    # runPartial script uses — are properly awaited rather than resolving
+    # immediately to the Promise object (which the polling polyfill cannot
+    # handle).
+    def execute_async_script_fixed(script, *args)
+      @driver.evaluate_async_script(script, *args)
+    end
+
+    def assert_context_supported!(context, skip_iframes = false)
+      raise_unsupported_iframe! if iframe_context?(context)
+      return if skip_iframes
+
+      assert_current_document_has_no_frames!
+    end
+
+    private
+
+    def assert_current_document_has_no_frames!
+      script = "return document.querySelectorAll('iframe, frame').length;"
+      raise_unsupported_iframe! if execute_script_fixed(script).to_i > 0
+    end
+
+    def iframe_context?(context)
+      selectors = Array(context_value(context, "include")) + Array(context_value(context, "exclude"))
+      selectors.any? { |selector| selector.is_a?(::Array) && selector.length > 1 }
+    end
+
+    def context_value(context, key)
+      context[key] || context[key.to_sym]
+    end
+
+    def raise_unsupported_iframe!
+      raise WebDriverError, UNSUPPORTED_IFRAME_MESSAGE
+    end
+  end
+end

--- a/packages/axe-core-api/lib/webdriver_script_adapter/cuprite_adapter.rb
+++ b/packages/axe-core-api/lib/webdriver_script_adapter/cuprite_adapter.rb
@@ -83,9 +83,24 @@ module WebDriverScriptAdapter
   # the RAW Cuprite driver (not the wrapped chain) so #browser and the *_fixed
   # methods bypass the Selenium-native assumptions baked into the inner chain.
   class CupriteAdapter < ::DumbDelegator
+    # Raised when the CURRENT document contains frames. skip_iframes DOES bypass
+    # this (it audits only the top-level document), so recommending it is correct.
     UNSUPPORTED_IFRAME_MESSAGE = "Cuprite iframe auditing is not supported yet. " \
       "Set Axe::Configuration#skip_iframes=true to audit only the top-level document, " \
       "or use a Selenium-backed driver for iframe audits."
+
+    # Raised for multi-element context selectors. axe uses the nested-array form for
+    # BOTH iframe chains and shadow-DOM piercing, so this rejection is conservative:
+    # it fires before the skip_iframes gate (a frame-targeting selector still can't
+    # be honoured under skip_iframes), which is why it must NOT recommend skip_iframes.
+    # Whole-page and single-selector audits already pierce open shadow DOM
+    # automatically; only element-scoped shadow targeting via this syntax is blocked.
+    UNSUPPORTED_IFRAME_SELECTOR_MESSAGE = "Multi-element selectors " \
+      "(e.g. [['#outer', '#inner']]) are treated as iframe selectors, which Cuprite " \
+      "cannot audit yet. axe still pierces open shadow DOM automatically for whole-page " \
+      "and single-selector audits; to scope to a specific shadow-DOM-nested element via " \
+      "this syntax, use a Selenium-backed driver for now. (skip_iframes does not bypass " \
+      "this check.)"
 
     def self.cuprite_driver?(driver)
       !!(defined?(::Capybara::Cuprite::Driver) && driver.is_a?(::Capybara::Cuprite::Driver))
@@ -113,6 +128,13 @@ module WebDriverScriptAdapter
     #     Promise.resolve, because Ferrum's evaluate_async uses awaitPromise:true.
     # The Ferrum template appends its resolve-callback as the last argument,
     # so we split user args from the callback before re-applying.
+    # Sentinel key for exceptions caught by the wrapper below. Deliberately
+    # distinct from axe's protocol "errorMessage" (which get_frame_context_script
+    # and axe_run_partial return as data the recursion inspects) so that a
+    # genuine JS throw here raises, while a legitimate {errorMessage: ...} result
+    # flows back to run.rb's throw/return-[nil] control flow unchanged.
+    WRAPPER_ERROR_KEY = "__cupriteWrapperError"
+
     def execute_script_fixed(script, *args)
       wrapper = <<~JS
         var __args = Array.prototype.slice.call(arguments, 0, arguments.length - 1);
@@ -120,15 +142,15 @@ module WebDriverScriptAdapter
         try {
           var __result = (function() { #{script} }).apply(this, __args);
           Promise.resolve(__result).then(__cb).catch(function(e) {
-            __cb({ errorMessage: e.message });
+            __cb({ #{WRAPPER_ERROR_KEY}: e.message });
           });
         } catch(e) {
-          __cb({ errorMessage: e.message });
+          __cb({ #{WRAPPER_ERROR_KEY}: e.message });
         }
       JS
       result = @driver.evaluate_async_script(wrapper, *args)
-      if result.respond_to?(:key?) && result.key?("errorMessage")
-        raise WebDriverError, result["errorMessage"]
+      if result.respond_to?(:key?) && result.key?(WRAPPER_ERROR_KEY)
+        raise WebDriverError, result[WRAPPER_ERROR_KEY]
       end
 
       result
@@ -144,7 +166,7 @@ module WebDriverScriptAdapter
     end
 
     def assert_context_supported!(context, skip_iframes = false)
-      raise_unsupported_iframe! if iframe_context?(context)
+      raise_unsupported_iframe_selector! if iframe_context?(context)
       return if skip_iframes
 
       assert_current_document_has_no_frames!
@@ -168,6 +190,10 @@ module WebDriverScriptAdapter
 
     def raise_unsupported_iframe!
       raise WebDriverError, UNSUPPORTED_IFRAME_MESSAGE
+    end
+
+    def raise_unsupported_iframe_selector!
+      raise WebDriverError, UNSUPPORTED_IFRAME_SELECTOR_MESSAGE
     end
   end
 end

--- a/packages/axe-core-api/spec/axe/api/run_spec.rb
+++ b/packages/axe-core-api/spec/axe/api/run_spec.rb
@@ -87,6 +87,33 @@ module Axe::API
       end
     end
 
+    describe "#analyze_post_43x" do
+      let(:timeouts) { Struct.new(:page_load).new(10) }
+      let(:manage) { double("manage", timeouts: timeouts) }
+      let(:selenium) { double("selenium", manage: manage) }
+      let(:page) { double("page", assert_context_supported!: nil) }
+      let(:configuration) { double("configuration", skip_iframes: nil) }
+      let(:lib) { "{}" }
+
+      before do
+        allow(Axe::Configuration).to receive(:instance).and_return(configuration)
+        allow(subject).to receive(:get_selenium).and_return(selenium)
+        allow(subject).to receive(:window_handle).and_return("win-1")
+        allow(subject).to receive(:within_about_blank_context).and_return({ "violations" => [] })
+      end
+
+      it "asks Cuprite-like pages to validate iframe contexts before running partials" do
+        subject.within iframe: "#child", selector: "#bad"
+
+        expect(page).to receive(:assert_context_supported!)
+          .with({ "include" => [["#child", "#bad"]] }, configuration.skip_iframes)
+          .ordered
+        expect(subject).to receive(:run_partial_recursive).with(page, anything, lib, true).ordered.and_return([])
+
+        subject.analyze_post_43x(page, lib)
+      end
+    end
+
     describe "#run_partial_recursive" do
       let(:context) { spy("context") }
       before :each do
@@ -120,6 +147,18 @@ module Axe::API
         expect(subject.send :run_partial_recursive, page, context, lib, false).to eq [nil]
       end
 
+    end
+
+    describe "#get_frame_context_script" do
+      it "does not discover frame contexts when iframe auditing is skipped" do
+        page = spy("page")
+        configuration = double("configuration", skip_iframes: true)
+
+        allow(Axe::Configuration).to receive(:instance).and_return(configuration)
+
+        expect(subject.send(:get_frame_context_script, page)).to eq []
+        expect(page).not_to have_received(:execute_script_fixed)
+      end
     end
   end
 end

--- a/packages/axe-core-api/spec/cuprite_adapter_spec.rb
+++ b/packages/axe-core-api/spec/cuprite_adapter_spec.rb
@@ -67,11 +67,22 @@ RSpec.describe WebDriverScriptAdapter::CupriteAdapter do
       .with(a_string_including("return window.axe.utils.getFrameContexts(arguments[0]);"), { "include" => "#main" })
   end
 
-  it "raises when the sync wrapper returns an errorMessage" do
-    allow(raw_driver).to receive(:evaluate_async_script).and_return({ "errorMessage" => "boom" })
+  it "raises when the wrapper catches a JS exception" do
+    allow(raw_driver).to receive(:evaluate_async_script)
+      .and_return({ described_class::WRAPPER_ERROR_KEY => "boom" })
 
     expect { adapter.execute_script_fixed("throw new Error('boom');") }
       .to raise_error(WebDriverScriptAdapter::WebDriverError, /boom/)
+  end
+
+  it "passes a protocol errorMessage result through instead of raising" do
+    # axe's getFrameContexts/runPartial return {errorMessage: ...} as data the
+    # run.rb recursion inspects; the adapter must not intercept it.
+    payload = { "errorMessage" => "frame boom" }
+    allow(raw_driver).to receive(:evaluate_async_script).and_return(payload)
+
+    expect(adapter.execute_script_fixed("return window.axe.utils.getFrameContexts(arguments[0]);"))
+      .to eq(payload)
   end
 
   it "delegates execute_async_script_fixed directly to evaluate_async_script on the raw driver" do
@@ -85,16 +96,26 @@ RSpec.describe WebDriverScriptAdapter::CupriteAdapter do
   end
 
   describe "#assert_context_supported!" do
-    it "raises for explicit iframe inclusion contexts" do
+    it "raises for multi-element inclusion selectors" do
       expect {
         adapter.assert_context_supported!({ "include" => [["#child", "#bad"]] })
-      }.to raise_error(WebDriverScriptAdapter::WebDriverError, /iframe auditing is not supported/)
+      }.to raise_error(WebDriverScriptAdapter::WebDriverError, /Multi-element selectors/)
     end
 
-    it "raises for explicit iframe exclusion contexts with symbol keys" do
+    it "raises for multi-element exclusion selectors with symbol keys" do
       expect {
         adapter.assert_context_supported!({ exclude: [["#child", "#bad"]] })
-      }.to raise_error(WebDriverScriptAdapter::WebDriverError, /iframe auditing is not supported/)
+      }.to raise_error(WebDriverScriptAdapter::WebDriverError, /Multi-element selectors/)
+    end
+
+    it "does not recommend skip_iframes in the multi-element selector message" do
+      # The selector check fires BEFORE the skip_iframes gate, so skip_iframes
+      # cannot bypass it — the message must not suggest otherwise.
+      expect {
+        adapter.assert_context_supported!({ "include" => [["#child", "#bad"]] }, true)
+      }.to raise_error(WebDriverScriptAdapter::WebDriverError) { |e|
+        expect(e.message).not_to match(/skip_iframes=true to audit/)
+      }
     end
 
     it "allows top-level selector contexts when the document has no frames" do

--- a/packages/axe-core-api/spec/cuprite_adapter_spec.rb
+++ b/packages/axe-core-api/spec/cuprite_adapter_spec.rb
@@ -1,0 +1,137 @@
+require "webdriver_script_adapter/cuprite_adapter"
+
+RSpec.describe WebDriverScriptAdapter::CupriteBrowserFacade do
+  let(:driver) do
+    instance_double(
+      "Capybara::Cuprite::Driver",
+      visit: nil, execute_script: nil, window_handle: "win-1",
+      window_handles: ["win-1"], switch_to_window: nil, close_window: nil,
+      switch_to_frame: nil, timeout: 5
+    )
+  end
+  subject(:facade) { described_class.new(driver) }
+
+  it "maps get to Cuprite#visit" do
+    facade.get("about:blank")
+    expect(driver).to have_received(:visit).with("about:blank")
+  end
+
+  it "exposes a page_load timeout that round-trips (no-op backed)" do
+    facade.manage.timeouts.page_load = 1
+    expect(facade.manage.timeouts.page_load).to eq(1)
+  end
+
+  it "routes switch_to.window to Cuprite#switch_to_window" do
+    facade.switch_to.window("win-2")
+    expect(driver).to have_received(:switch_to_window).with("win-2")
+  end
+
+  it "routes switch_to.parent_frame to switch_to_frame(:parent)" do
+    facade.switch_to.parent_frame
+    expect(driver).to have_received(:switch_to_frame).with(:parent)
+  end
+
+  it "delegates execute_script with args to the driver" do
+    facade.execute_script("return 1;", "a")
+    expect(driver).to have_received(:execute_script).with("return 1;", "a")
+  end
+
+  it "closes the current window" do
+    facade.close
+    expect(driver).to have_received(:close_window).with("win-1")
+  end
+end
+
+RSpec.describe WebDriverScriptAdapter::CupriteAdapter do
+  let(:raw_driver) do
+    instance_double(
+      "Capybara::Cuprite::Driver",
+      evaluate_async_script: nil
+    )
+  end
+  let(:chain) { Object.new }
+  subject(:adapter) { described_class.wrap(chain, raw_driver) }
+
+  it "returns a CupriteBrowserFacade from #browser" do
+    expect(adapter.browser).to be_a(WebDriverScriptAdapter::CupriteBrowserFacade)
+  end
+
+  it "wraps execute_script_fixed in an async shim and calls evaluate_async_script" do
+    # Ferrum's evaluate_async_script uses awaitPromise: true, so both sync
+    # values and Promise-returning scripts (e.g. axe.finishRun) are handled.
+    allow(raw_driver).to receive(:evaluate_async_script).and_return([])
+    result = adapter.execute_script_fixed("return window.axe.utils.getFrameContexts(arguments[0]);", { "include" => "#main" })
+    expect(result).to eq([])
+    # The original script body is embedded in the wrapper passed to evaluate_async_script.
+    expect(raw_driver).to have_received(:evaluate_async_script)
+      .with(a_string_including("return window.axe.utils.getFrameContexts(arguments[0]);"), { "include" => "#main" })
+  end
+
+  it "raises when the sync wrapper returns an errorMessage" do
+    allow(raw_driver).to receive(:evaluate_async_script).and_return({ "errorMessage" => "boom" })
+
+    expect { adapter.execute_script_fixed("throw new Error('boom');") }
+      .to raise_error(WebDriverScriptAdapter::WebDriverError, /boom/)
+  end
+
+  it "delegates execute_async_script_fixed directly to evaluate_async_script on the raw driver" do
+    # Native evaluate_async_script uses Ferrum's evaluate_async with awaitPromise: true,
+    # which correctly awaits a Promise passed to the callback (cb(promise) pattern).
+    allow(raw_driver).to receive(:evaluate_async_script).and_return({ "violations" => [] })
+    result = adapter.execute_async_script_fixed("axe.runPartial(arguments[0], arguments[1])", { "include" => "#main" }, {})
+    expect(result).to eq({ "violations" => [] })
+    expect(raw_driver).to have_received(:evaluate_async_script)
+      .with("axe.runPartial(arguments[0], arguments[1])", { "include" => "#main" }, {})
+  end
+
+  describe "#assert_context_supported!" do
+    it "raises for explicit iframe inclusion contexts" do
+      expect {
+        adapter.assert_context_supported!({ "include" => [["#child", "#bad"]] })
+      }.to raise_error(WebDriverScriptAdapter::WebDriverError, /iframe auditing is not supported/)
+    end
+
+    it "raises for explicit iframe exclusion contexts with symbol keys" do
+      expect {
+        adapter.assert_context_supported!({ exclude: [["#child", "#bad"]] })
+      }.to raise_error(WebDriverScriptAdapter::WebDriverError, /iframe auditing is not supported/)
+    end
+
+    it "allows top-level selector contexts when the document has no frames" do
+      allow(raw_driver).to receive(:evaluate_async_script).and_return(0)
+
+      expect {
+        adapter.assert_context_supported!({ "include" => ["#main"] })
+      }.not_to raise_error
+    end
+
+    it "raises when the current document contains frames" do
+      allow(raw_driver).to receive(:evaluate_async_script).and_return(1)
+
+      expect {
+        adapter.assert_context_supported!({ "exclude" => [] })
+      }.to raise_error(WebDriverScriptAdapter::WebDriverError, /iframe auditing is not supported/)
+    end
+
+    it "allows current document frames when skip_iframes is enabled" do
+      expect {
+        adapter.assert_context_supported!({ "exclude" => [] }, true)
+      }.not_to raise_error
+      expect(raw_driver).not_to have_received(:evaluate_async_script)
+    end
+  end
+
+  it "delegates unknown methods to the wrapped chain" do
+    def chain.evaluate_script(_script)
+      "chained"
+    end
+
+    expect(adapter.evaluate_script("window.axe")).to eq("chained")
+  end
+
+  describe ".cuprite_driver?" do
+    it "is false for a non-cuprite object" do
+      expect(described_class.cuprite_driver?(Object.new)).to be(false)
+    end
+  end
+end

--- a/packages/axe-core-cuprite/.gitignore
+++ b/packages/axe-core-cuprite/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/packages/axe-core-cuprite/Gemfile
+++ b/packages/axe-core-cuprite/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec
+
+gem "axe-core-api", :path => "../axe-core-api"

--- a/packages/axe-core-cuprite/LICENSE
+++ b/packages/axe-core-cuprite/LICENSE
@@ -1,0 +1,362 @@
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. "Contributor"
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+
+     means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the terms of
+        a Secondary License.
+
+1.6. "Executable Form"
+
+     means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+
+     means a work that combines Covered Software with other material, in a
+     separate file or files, that is not Covered Software.
+
+1.8. "License"
+
+     means this document.
+
+1.9. "Licensable"
+
+     means having the right to grant, to the maximum extent possible, whether
+     at the time of the initial grant or subsequently, any and all of the
+     rights conveyed by this License.
+
+1.10. "Modifications"
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. "Patent Claims" of a Contributor
+
+      means any patent claim(s), including without limitation, method,
+      process, and apparatus claims, in any patent Licensable by such
+      Contributor that would be infringed, but for the grant of the License,
+      by the making, using, selling, offering for sale, having made, import,
+      or transfer of either its Contributions or its Contributor Version.
+
+1.12. "Secondary License"
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. "Source Code Form"
+
+      means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, "You" includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, "control" means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or
+        as part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its
+        Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution
+     become effective for each Contribution on the date the Contributor first
+     distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under
+     this License. No additional rights or licenses will be implied from the
+     distribution or licensing of Covered Software under this License.
+     Notwithstanding Section 2.1(b) above, no patent license is granted by a
+     Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party's
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of
+        its Contributions.
+
+     This License does not grant any rights in the trademarks, service marks,
+     or logos of any Contributor (except as may be necessary to comply with
+     the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this
+     License (see Section 10.2) or under the terms of a Secondary License (if
+     permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its
+     Contributions are its original creation(s) or it has sufficient rights to
+     grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under
+     applicable copyright doctrines of fair use, fair dealing, or other
+     equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under
+     the terms of this License. You must inform recipients that the Source
+     Code Form of the Covered Software is governed by the terms of this
+     License, and how they can obtain a copy of this License. You may not
+     attempt to alter or restrict the recipients' rights in the Source Code
+     Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this
+        License, or sublicense it under different terms, provided that the
+        license for the Executable Form does not attempt to limit or alter the
+        recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for
+     the Covered Software. If the Larger Work is a combination of Covered
+     Software with a work governed by one or more Secondary Licenses, and the
+     Covered Software is not Incompatible With Secondary Licenses, this
+     License permits You to additionally distribute such Covered Software
+     under the terms of such Secondary License(s), so that the recipient of
+     the Larger Work may, at their option, further distribute the Covered
+     Software under the terms of either this License or such Secondary
+     License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices
+     (including copyright notices, patent notices, disclaimers of warranty, or
+     limitations of liability) contained within the Source Code Form of the
+     Covered Software, except that You may alter any license notices to the
+     extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on
+     behalf of any Contributor. You must make it absolutely clear that any
+     such warranty, support, indemnity, or liability obligation is offered by
+     You alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute,
+   judicial order, or regulation then You must: (a) comply with the terms of
+   this License to the maximum extent possible; and (b) describe the
+   limitations and the code they affect. Such description must be placed in a
+   text file included with all distributions of the Covered Software under
+   this License. Except to the extent prohibited by statute or regulation,
+   such description must be sufficiently detailed for a recipient of ordinary
+   skill to be able to understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing
+     basis, if such Contributor fails to notify You of the non-compliance by
+     some reasonable means prior to 60 days after You have come back into
+     compliance. Moreover, Your grants from a particular Contributor are
+     reinstated on an ongoing basis if such Contributor notifies You of the
+     non-compliance by some reasonable means, this is the first time You have
+     received notice of non-compliance with this License from such
+     Contributor, and You become compliant prior to 30 days after Your receipt
+     of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions,
+     counter-claims, and cross-claims) alleging that a Contributor Version
+     directly or indirectly infringes any patent, then the rights granted to
+     You by any and all Contributors for the Covered Software under Section
+     2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an "as is" basis,
+   without warranty of any kind, either expressed, implied, or statutory,
+   including, without limitation, warranties that the Covered Software is free
+   of defects, merchantable, fit for a particular purpose or non-infringing.
+   The entire risk as to the quality and performance of the Covered Software
+   is with You. Should any Covered Software prove defective in any respect,
+   You (not any Contributor) assume the cost of any necessary servicing,
+   repair, or correction. This disclaimer of warranty constitutes an essential
+   part of this License. No use of  any Covered Software is authorized under
+   this License except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from
+   such party's negligence to the extent applicable law prohibits such
+   limitation. Some jurisdictions do not allow the exclusion or limitation of
+   incidental or consequential damages, so this exclusion and limitation may
+   not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts
+   of a jurisdiction where the defendant maintains its principal place of
+   business and such litigation shall be governed by laws of that
+   jurisdiction, without reference to its conflict-of-law provisions. Nothing
+   in this Section shall prevent a party's ability to bring cross-claims or
+   counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject
+   matter hereof. If any provision of this License is held to be
+   unenforceable, such provision shall be reformed only to the extent
+   necessary to make it enforceable. Any law or regulation which provides that
+   the language of a contract shall be construed against the drafter shall not
+   be used to construe this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version
+      of the License under which You originally received the Covered Software,
+      or under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a
+      modified version of this License if you rename the license and remove
+      any references to the name of the license steward (except to note that
+      such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+      Licenses If You choose to distribute Source Code Form that is
+      Incompatible With Secondary Licenses under the terms of this version of
+      the License, the notice described in Exhibit B of this License must be
+      attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file,
+then You may include the notice in a location (such as a LICENSE file in a
+relevant directory) where a recipient would be likely to look for such a
+notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+
+      This Source Code Form is "Incompatible
+      With Secondary Licenses", as defined by
+      the Mozilla Public License, v. 2.0.

--- a/packages/axe-core-cuprite/README.md
+++ b/packages/axe-core-cuprite/README.md
@@ -1,0 +1,103 @@
+# `axe-core-cuprite`
+
+The `axe-core-cuprite` gem provides a chainable [axe API][] for [Cuprite][] (a Ferrum/Chrome DevTools Protocol Capybara driver). Current support is limited to top-level document audits; iframe auditing under Cuprite is not supported yet.
+
+## Usage
+
+- In your Gemfile, add the `axe-core-cuprite` gem.
+
+```Gemfile
+source "https://rubygems.org"
+
+gem 'axe-core-cuprite'
+gem 'cuprite'
+```
+
+The `axe-core-cuprite` gem assumes your application already depends on and configures `cuprite`. If not, add `gem 'cuprite'` to your application Gemfile.
+
+- Require `axe-cuprite` and use the exported member `AxeCuprite`.
+
+```rb
+require 'axe-cuprite'
+require 'axe-rspec'
+
+# Configure AxeCuprite with optional driver options
+AxeCuprite.configure(headless: true, window_size: [1200, 800]) do |config|
+  # see below for a full list of configuration
+  config.jslib_path = "next-version/axe.js"
+end
+```
+
+- Use with Capybara and RSpec:
+
+```rb
+require 'capybara/rspec'
+require 'axe-cuprite'
+require 'axe-rspec'
+
+Capybara.register_driver(:cuprite) do |app|
+  Capybara::Cuprite::Driver.new(app, headless: true)
+end
+
+Capybara.default_driver = :cuprite
+Capybara.javascript_driver = :cuprite
+
+RSpec.describe "Accessibility", type: :feature do
+  it "is accessible" do
+    visit "https://www.example.com/"
+    expect(page).to be_axe_clean
+  end
+end
+```
+
+### API
+
+#### `AxeCuprite.configure`
+
+The configure method takes an optional hash of driver options and requires a configuration block: `configure(options = {}, &block)`
+
+The `options` hash is passed directly to `Capybara::Cuprite::Driver.new`. Common options include:
+
+| Option | Type | Description |
+|---|---|---|
+| `headless` (Optional) | `Boolean` | Run Chrome in headless mode (default: true) |
+| `window_size` (Optional) | `Array` | Browser window dimensions, e.g. `[1200, 800]` |
+| `browser_options` (Optional) | `Hash` | Additional Chrome options |
+
+The block configuration object (an `Axe::Configuration` instance) supports:
+
+| Property | Type | Description |
+|---|---|---|
+| `jslib_path` (Optional) | `String` | Path to a custom `axe` source |
+| `skip_iframes` (Optional) | `Boolean` | Permit top-level-only audits on pages that contain iframes |
+
+## Known Limitations
+
+Iframe auditing is not yet supported under Cuprite. Cuprite's `switch_to_frame`
+resolves a frame only from a Capybara element, while axe's frame traversal passes
+driver nodes. Top-level document audits are supported. Pages containing iframes
+can be audited as top-level-only documents by setting
+`Axe::Configuration#skip_iframes = true`; explicit `within(iframe: ...)` and
+`excluding(iframe: ...)` contexts still raise an unsupported-driver error. Use a
+Selenium-backed gem when iframe auditing is required.
+Tracking: [#508](https://github.com/dequelabs/axe-core-gems/issues/508).
+
+> Note: Please ensure [Google Chrome or Chromium][] is installed on your machine.
+
+## Development
+
+Navigate to the directory of this gem — `packages/axe-core-cuprite`
+
+Install dependencies (declared in `axe-core-cuprite.gemspec`):
+```sh
+bundle install
+```
+
+To run tests:
+```sh
+bundle exec rspec
+```
+
+[axe API]: https://github.com/dequelabs/axe-core/blob/develop/doc/API.md
+[Cuprite]: https://github.com/rubycdp/cuprite
+[Google Chrome or Chromium]: https://www.google.com/chrome/

--- a/packages/axe-core-cuprite/Rakefile
+++ b/packages/axe-core-cuprite/Rakefile
@@ -1,0 +1,32 @@
+require "rake/clean"
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+# clean
+CLOBBER.include "pkg"
+
+RSpec::Core::RakeTask.new(:spec)
+
+# default task
+task :default => :spec
+
+# build
+Rake::Task[:build]
+
+# unit tests
+desc "Tests Unit"
+task :test_unit do
+  sh "bundle exec rake"
+end
+
+# format code
+desc "Format code using rubocop"
+task :format => [] do
+  sh "bundle exec rubocop --config rubocop.yml --auto-correct --fix-layout"
+end
+
+#  publish
+desc "publish package"
+task :publish => [:build] do
+  sh "gem push $(ls pkg/*.gem)"
+end

--- a/packages/axe-core-cuprite/axe-core-cuprite.gemspec
+++ b/packages/axe-core-cuprite/axe-core-cuprite.gemspec
@@ -1,0 +1,34 @@
+# coding: utf-8
+
+require_relative "../../version"
+
+Gem::Specification.new do |spec|
+  spec.name = "axe-core-cuprite"
+  spec.summary = "Cuprite (Ferrum/CDP) driver injected with Axe"
+
+  spec.version = AxeCoreGems::VERSION
+  spec.authors = ["Deque Systems"]
+  spec.email = ["helpdesk@deque.com"]
+  spec.homepage = "https://www.deque.com"
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "https://github.com/dequelabs/axe-core-gems"
+  spec.metadata["bug_tracker_uri"] = "https://github.com/dequelabs/axe-core-gems/issues"
+  spec.platform = Gem::Platform::RUBY
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.require_paths = ["lib"]
+  spec.files = Dir.glob %w[
+    lib/**/*
+    LICENSE
+    README.md
+  ]
+
+  # pin to a specific version of axe-core-api
+  spec.add_dependency "axe-core-api", AxeCoreGems::VERSION
+
+  spec.add_development_dependency "bundler", "~> 2.1"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec-its"
+  spec.add_development_dependency "capybara"
+  spec.add_development_dependency "cuprite"
+end

--- a/packages/axe-core-cuprite/lib/axe-cuprite.rb
+++ b/packages/axe-core-cuprite/lib/axe-cuprite.rb
@@ -1,0 +1,20 @@
+require "capybara/cuprite"
+require "axe/configuration"
+
+module AxeCuprite
+  # - options: an optional hash passed to Capybara::Cuprite::Driver
+  # - requires a configuration block for Axe
+  def self.configure(options = {})
+    raise ArgumentError, "Please provide a configure block for AxeCuprite" unless block_given?
+
+    config = Axe::Configuration.instance
+    config.page = get_driver(options)
+    yield config
+    config
+  end
+
+  def self.get_driver(options)
+    Capybara::Cuprite::Driver.new(nil, options)
+  end
+  private_class_method :get_driver
+end

--- a/packages/axe-core-cuprite/rubocop.yml
+++ b/packages/axe-core-cuprite/rubocop.yml
@@ -1,0 +1,4 @@
+# rubocop.yml
+
+Style/ClassAndModuleChildren:
+  EnforcedStyle: compact

--- a/packages/axe-core-cuprite/spec/axe-cuprite_spec.rb
+++ b/packages/axe-core-cuprite/spec/axe-cuprite_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+require "axe-cuprite"
+
+RSpec.describe AxeCuprite do
+  before { Axe::Configuration.instance.page = nil }
+
+  it "raises without a configure block" do
+    expect { AxeCuprite.configure }.to raise_error(ArgumentError, /configure block/)
+  end
+
+  it "sets Axe::Configuration#page to a Cuprite driver" do
+    AxeCuprite.configure do |config|
+      expect(config.page).to be_a(Capybara::Cuprite::Driver)
+    end
+  end
+
+  it "accepts driver options as a positional hash" do
+    AxeCuprite.configure(headless: true, window_size: [1200, 800]) do |config|
+      expect(config.page).to be_a(Capybara::Cuprite::Driver)
+    end
+  end
+end

--- a/packages/axe-core-cuprite/spec/spec_helper.rb
+++ b/packages/axe-core-cuprite/spec/spec_helper.rb
@@ -1,0 +1,6 @@
+require "rspec"
+require "rspec/its"
+
+RSpec.configure do |config|
+  config.color = true
+end

--- a/packages/axe-core-rspec/Rakefile
+++ b/packages/axe-core-rspec/Rakefile
@@ -25,8 +25,13 @@ task :test_e2e_capybara do
   sh "cd e2e/capybara && bundle install && bundle exec rspec"
 end
 
+task :test_e2e_cuprite do
+  sh "cd e2e/cuprite && bundle install && bundle exec rspec"
+end
+
 task :test_e2e => [
   "test_e2e_capybara",
+  "test_e2e_cuprite",
 ] do
 end
 

--- a/packages/axe-core-rspec/e2e/cuprite/Gemfile
+++ b/packages/axe-core-rspec/e2e/cuprite/Gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem "rspec"
+gem "capybara"
+gem "cuprite"
+gem "puma"
+gem "axe-core-api", :path => "../../../axe-core-api"
+gem "axe-core-rspec", :path => "../../"

--- a/packages/axe-core-rspec/e2e/cuprite/spec/a11y_spec.rb
+++ b/packages/axe-core-rspec/e2e/cuprite/spec/a11y_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+describe "axe under Cuprite (baseline)", :type => :feature do
+  before(:each) { visit("/") }
+
+  it "audits the accessible region (single document, no iframe)" do
+    expect(page).to be_axe_clean.within "#content"
+  end
+
+  it "flags the inaccessible region" do
+    expect(page).not_to be_axe_clean.within "#bad"
+  end
+end
+
+describe "axe under Cuprite with iframes", :type => :feature do
+  before(:each) { visit("/with-iframe") }
+
+  it "raises instead of false-greening whole-page iframe audits" do
+    expect {
+      expect(page).to be_axe_clean
+    }.to raise_error(/iframe auditing is not supported/)
+  end
+
+  it "raises instead of false-greening explicit iframe contexts" do
+    expect {
+      expect(page).to be_axe_clean.within iframe: "#child", selector: "#bad"
+    }.to raise_error(/iframe auditing is not supported/)
+  end
+
+  it "audits only the top-level document when iframe auditing is skipped" do
+    original_skip_iframes = Axe::Configuration.instance.skip_iframes
+    Axe::Configuration.instance.skip_iframes = true
+
+    expect(page).to be_axe_clean
+  ensure
+    Axe::Configuration.instance.skip_iframes = original_skip_iframes
+  end
+end

--- a/packages/axe-core-rspec/e2e/cuprite/spec/spec_helper.rb
+++ b/packages/axe-core-rspec/e2e/cuprite/spec/spec_helper.rb
@@ -1,0 +1,66 @@
+require "rspec"
+require "capybara/rspec"
+require "capybara/cuprite"
+require "axe-rspec"
+
+# A known-accessible page and a known-inaccessible region, served in-process
+# so the suite is deterministic and offline.
+FIXTURE_HTML = <<~HTML
+  <!DOCTYPE html>
+  <html lang="en">
+    <head><meta charset="utf-8"><title>Cuprite axe fixture</title></head>
+    <body>
+      <main id="content">
+        <h1>Accessible heading</h1>
+        <p>Readable paragraph with sufficient contrast.</p>
+      </main>
+      <div id="bad">
+        <img src="data:image/gif;base64,R0lGODlhAQABAAAAACw=">
+      </div>
+    </body>
+  </html>
+HTML
+
+IFRAME_HTML = <<~HTML
+  <!DOCTYPE html>
+  <html lang="en">
+    <head><meta charset="utf-8"><title>Cuprite iframe fixture</title></head>
+    <body>
+      <main id="content">
+        <h1>Parent document</h1>
+        <iframe id="child" title="Child frame" src="/child"></iframe>
+      </main>
+    </body>
+  </html>
+HTML
+
+CHILD_HTML = <<~HTML
+  <!DOCTYPE html>
+  <html lang="en">
+    <head><meta charset="utf-8"><title>Child fixture</title></head>
+    <body>
+      <h2>Child document</h2>
+      <img id="bad" src="data:image/gif;base64,R0lGODlhAQABAAAAACw=">
+    </body>
+  </html>
+HTML
+
+Capybara.app = lambda do |env|
+  html = case env["PATH_INFO"]
+         when "/with-iframe" then IFRAME_HTML
+         when "/child" then CHILD_HTML
+         else FIXTURE_HTML
+         end
+  [200, { "Content-Type" => "text/html" }, [html]]
+end
+
+Capybara.register_driver(:cuprite) do |app|
+  Capybara::Cuprite::Driver.new(app, window_size: [1200, 800], headless: true)
+end
+
+Capybara.default_driver = :cuprite
+Capybara.javascript_driver = :cuprite
+
+RSpec.configure do |config|
+  config.color = true
+end


### PR DESCRIPTION
Closes #508.

## What

Adds support for running axe-core accessibility audits under the **Cuprite** (Ferrum / Chrome DevTools Protocol) Capybara driver, which previously only worked under Selenium in practice.

Scope is **top-level document auditing**. Iframe traversal is explicitly unsupported under Cuprite for now: pages containing frames raise an unsupported-driver error unless `Axe::Configuration#skip_iframes = true` is set, in which case axe audits only the top-level document. Explicit `within(iframe: ...)` / `excluding(iframe: ...)` contexts still raise.

## Why

`Axe::API::Run#analyze_post_43x` is hard-wired to Selenium driver semantics (`manage.timeouts`, `switch_to.*`, `get`, native async script execution). Several of those calls fire on every audit, so axe was unusable under Cuprite even for iframe-free pages, forcing downstream consumers onto a Selenium fallback.

## How

- New `CupriteAdapter` (+ `CupriteBrowserFacade`) in `axe-core-api` presents the Selenium-shaped surface that `run.rb` expects, while keeping Cuprite-specific behavior in one adapter.
- `Axe::Core#wrap_driver` selects the adapter via a `defined?`-guarded type check, so `axe-core-api` does not take a hard dependency on Cuprite.
- `Axe::API::Run#analyze_post_43x` asks adapters that support it to validate the current axe context before running, which prevents Cuprite iframe false-greens.
- The post-4.3 partial-run path now also honors `Axe::Configuration#skip_iframes` by suppressing frame-context discovery, so Cuprite can audit iframe-containing pages as top-level-only documents.
- Async execution delegates to Cuprite's native `evaluate_async_script` (Ferrum `evaluate_async`, CDP `awaitPromise: true`). This preserves axe's callback convention and correctly follows Promise-returning axe scripts.
- New thin `axe-core-cuprite` gem mirrors the sibling driver gems for driver registration/configuration.
- CI/Rake coverage now includes `axe-core-cuprite` unit tests and Cuprite e2e specs.

## Testing

- API unit specs cover `CupriteAdapter` / `CupriteBrowserFacade` delegation, async routing, script error propagation, driver detection, iframe/context guard behavior, and `skip_iframes` frame-discovery suppression.
- `Axe::API::Run` specs cover invoking the adapter context guard in the post-4.3 analysis path.
- `axe-core-cuprite` specs cover the configuration block requirement and option forwarding to `Capybara::Cuprite::Driver`.
- New e2e suite (`packages/axe-core-rspec/e2e/cuprite/`) runs a real Chrome audit via Cuprite: accessible content passes, inaccessible content is flagged, iframe cases raise instead of false-greening, and `skip_iframes=true` audits the top-level document only.

## Known limitations

Iframe auditing is not yet supported under Cuprite. Cuprite's `switch_to_frame` resolves a frame only from a Capybara element, while axe's frame traversal passes driver nodes. Use a Selenium-backed gem when iframe auditing is required. Tracking: #508.

Multi-element selectors (`[['#outer', '#inner']]`) are also rejected, since axe uses this syntax for both iframe chains and shadow-DOM piercing and the two are indistinguishable statically. Whole-page and single-selector audits still auto-pierce open shadow DOM; only element-scoped shadow targeting via this syntax is blocked. Runtime shadow-vs-iframe discrimination is deferred to the future iframe work (driver-level frame switching unblocked upstream by rubycdp/cuprite#312).

## Notes for reviewers

The branch has been squashed into three reviewable commits:

1. `feat(api): add Cuprite driver adapter`
2. `feat(cuprite): add Cuprite convenience gem`
3. `test(ci): add Cuprite e2e coverage`

